### PR TITLE
Added missing function to include X509 data to KeyInfo

### DIFF
--- a/src/xmlsec/template.pxd
+++ b/src/xmlsec/template.pxd
@@ -24,6 +24,20 @@ cdef extern from "xmlsec.h":  # xmlsec/templates.h
 
     xmlNode* xmlSecTmplKeyInfoAddX509Data(xmlNode* node) nogil
 
+    xmlNode* xmlSecTmplX509DataAddIssuerSerial(xmlNode* node) nogil
+
+    xmlNode* xmlSecTmplX509IssuerSerialAddIssuerName(xmlNode* node, const_xmlChar* name) nogil
+
+    xmlNode* xmlSecTmplX509IssuerSerialAddSerialNumber(xmlNode* node, const_xmlChar* serial) nogil
+
+    xmlNode* xmlSecTmplX509DataAddSubjectName(xmlNode* node) nogil
+
+    xmlNode* xmlSecTmplX509DataAddSKI (xmlNode* node) nogil
+
+    xmlNode* xmlSecTmplX509DataAddCertificate (xmlNode* node) nogil
+
+    xmlNode* xmlSecTmplX509DataAddCRL (xmlNode* node) nogil
+
     xmlNode* xmlSecTmplKeyInfoAddEncryptedKey(
         xmlNode* keyInfoNode, xmlSecTransformId encMethodId,
         const_xmlChar *id, const_xmlChar *type, const_xmlChar *recipient) nogil

--- a/src/xmlsec/template.pxd
+++ b/src/xmlsec/template.pxd
@@ -32,11 +32,11 @@ cdef extern from "xmlsec.h":  # xmlsec/templates.h
 
     xmlNode* xmlSecTmplX509DataAddSubjectName(xmlNode* node) nogil
 
-    xmlNode* xmlSecTmplX509DataAddSKI (xmlNode* node) nogil
+    xmlNode* xmlSecTmplX509DataAddSKI(xmlNode* node) nogil
 
-    xmlNode* xmlSecTmplX509DataAddCertificate (xmlNode* node) nogil
+    xmlNode* xmlSecTmplX509DataAddCertificate(xmlNode* node) nogil
 
-    xmlNode* xmlSecTmplX509DataAddCRL (xmlNode* node) nogil
+    xmlNode* xmlSecTmplX509DataAddCRL(xmlNode* node) nogil
 
     xmlNode* xmlSecTmplKeyInfoAddEncryptedKey(
         xmlNode* keyInfoNode, xmlSecTransformId encMethodId,

--- a/src/xmlsec/template.pyx
+++ b/src/xmlsec/template.pyx
@@ -89,6 +89,71 @@ def add_x509_data(_Element node not None):
     return elementFactory(node._doc, c_node)
 
 
+def x509_data_add_issuer_serial(_Element node not None):
+
+    cdef xmlNode* c_node
+
+    c_node = xmlSecTmplX509DataAddIssuerSerial(node._c_node)
+
+    return elementFactory(node._doc, c_node)
+
+
+def x509_issuer_serial_add_issuer_name(_Element node not None, name=None):
+
+    cdef xmlNode* c_node
+    cdef const_xmlChar* c_name = _b(name)
+
+    c_node = xmlSecTmplX509IssuerSerialAddIssuerName(node._c_node, c_name)
+
+    return elementFactory(node._doc, c_node)
+
+
+def x509_issuer_serial_add_serial_number(_Element node not None, serial=None):
+
+    cdef xmlNode* c_node
+    cdef const_xmlChar* c_serial = _b(serial)
+
+    c_node = xmlSecTmplX509IssuerSerialAddSerialNumber(node._c_node, c_serial)
+
+    return elementFactory(node._doc, c_node)
+
+
+def x509_data_add_subject_name(_Element node not None):
+
+    cdef xmlNode* c_node
+
+    c_node = xmlSecTmplX509DataAddSubjectName(node._c_node)
+
+    return elementFactory(node._doc, c_node)
+
+
+def x509_data_add_ski(_Element node not None):
+
+    cdef xmlNode* c_node
+
+    c_node = xmlSecTmplX509DataAddSKI(node._c_node)
+
+    return elementFactory(node._doc, c_node)
+
+
+def x509_data_add_certificate(_Element node not None):
+
+    cdef xmlNode* c_node
+
+    c_node = xmlSecTmplX509DataAddCertificate(node._c_node)
+
+    return elementFactory(node._doc, c_node)
+
+
+def x509_data_add_crl(_Element node not None):
+
+    cdef xmlNode* c_node
+
+    c_node = xmlSecTmplX509DataAddCRL(node._c_node)
+
+    return elementFactory(node._doc, c_node)
+
+
 def add_encrypted_key(_Element node not None,
                       _Transform method not None,
                       id=None,

--- a/tests/examples/base.py
+++ b/tests/examples/base.py
@@ -17,4 +17,7 @@ def compare(name, result):
     result_text = etree.tostring(result, pretty_print=False)
 
     # Compare the results.
+    if expected_text != result_text:
+        print(expected_text)
+        print(result_text)
     assert expected_text == result_text

--- a/tests/examples/base.py
+++ b/tests/examples/base.py
@@ -17,7 +17,4 @@ def compare(name, result):
     result_text = etree.tostring(result, pretty_print=False)
 
     # Compare the results.
-    if expected_text != result_text:
-        print(expected_text)
-        print(result_text)
     assert expected_text == result_text

--- a/tests/examples/sign5-doc.xml
+++ b/tests/examples/sign5-doc.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+XML Security Library example: Original XML doc file for sign5 example.
+-->
+<Envelope xmlns="urn:envelope">
+  <Data>
+	Hello, World!
+  </Data>
+</Envelope>

--- a/tests/examples/sign5-res.xml
+++ b/tests/examples/sign5-res.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+XML Security Library example: Signed XML doc file (sign5 example).
+-->
+<Envelope xmlns="urn:envelope">
+  <Data>
+	Hello, World!
+  </Data>
+<Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+<SignedInfo>
+<CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+<SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+<Reference>
+<Transforms>
+<Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+</Transforms>
+<DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+<DigestValue>HjY8ilZAIEM2tBbPn5mYO1ieIX4=</DigestValue>
+</Reference>
+</SignedInfo>
+<SignatureValue>SIaj/6KY3C1SmDXU2++Gm31U1xTadFp04WhBgfsJFbxrL+q7GKSKN9kfQ+UpN9+i
+D5fWmuavXEHe4Gw6RMaMEkq2URQo7F68+d5J/ajq8/l4n+xE6/reGScVwT6L4dEP
+XXVJcAi2ZnQ3O7GTNvNGCPibL9mUcyCWBFZ92Uemtc/vJFCQ7ZyKMdMfACgxOwyN
+T/9971oog241/2doudhonc0I/3mgPYWkZdX6yvr62mEjnG+oUZkhWYJ4ewZJ4hM4
+JjbFqZO+OEzDRSbw3DkmuBA/mtlx+3t13SESfEub5hqoMdVmtth/eTb64dsPdl9r
+3k1ACVX9f8aHfQQdJOmLFQ==</SignatureValue>
+<KeyInfo>
+<X509Data>
+
+
+
+<X509IssuerSerial>
+<X509IssuerName>Test Issuer</X509IssuerName>
+<X509SerialNumber>1</X509SerialNumber>
+</X509IssuerSerial>
+<X509Certificate>MIIE3zCCBEigAwIBAgIBBTANBgkqhkiG9w0BAQQFADCByzELMAkGA1UEBhMCVVMx
+EzARBgNVBAgTCkNhbGlmb3JuaWExEjAQBgNVBAcTCVN1bm55dmFsZTE9MDsGA1UE
+ChM0WE1MIFNlY3VyaXR5IExpYnJhcnkgKGh0dHA6Ly93d3cuYWxla3NleS5jb20v
+eG1sc2VjKTEZMBcGA1UECxMQUm9vdCBDZXJ0aWZpY2F0ZTEWMBQGA1UEAxMNQWxl
+a3NleSBTYW5pbjEhMB8GCSqGSIb3DQEJARYSeG1sc2VjQGFsZWtzZXkuY29tMB4X
+DTAzMDMzMTA0MDIyMloXDTEzMDMyODA0MDIyMlowgb8xCzAJBgNVBAYTAlVTMRMw
+EQYDVQQIEwpDYWxpZm9ybmlhMT0wOwYDVQQKEzRYTUwgU2VjdXJpdHkgTGlicmFy
+eSAoaHR0cDovL3d3dy5hbGVrc2V5LmNvbS94bWxzZWMpMSEwHwYDVQQLExhFeGFt
+cGxlcyBSU0EgQ2VydGlmaWNhdGUxFjAUBgNVBAMTDUFsZWtzZXkgU2FuaW4xITAf
+BgkqhkiG9w0BCQEWEnhtbHNlY0BhbGVrc2V5LmNvbTCCASIwDQYJKoZIhvcNAQEB
+BQADggEPADCCAQoCggEBAJe4/rQ/gzV4FokE7CthjL/EXwCBSkXm2c3p4jyXO0Wt
+quaNC3dxBwFPfPl94hmq3ZFZ9PHPPbp4RpYRnLZbRjlzVSOq954AXOXpSew7nD+E
+mTqQrd9+ZIbGJnLOMQh5fhMVuOW/1lYCjWAhTCcYZPv7VXD2M70vVXDVXn6ZrqTg
+qkVHE6gw1aCKncwg7OSOUclUxX8+Zi10v6N6+PPslFc5tKwAdWJhVLTQ4FKG+F53
+7FBDnNK6p4xiWryy/vPMYn4jYGvHUUk3eH4lFTCr+rSuJY8i/KNIf/IKim7g/o3w
+Ae3GM8xrof2mgO8GjK/2QDqOQhQgYRIf4/wFsQXVZcMCAwEAAaOCAVcwggFTMAkG
+A1UdEwQCMAAwLAYJYIZIAYb4QgENBB8WHU9wZW5TU0wgR2VuZXJhdGVkIENlcnRp
+ZmljYXRlMB0GA1UdDgQWBBQkhCzy1FkgYosuXIaQo6owuicanDCB+AYDVR0jBIHw
+MIHtgBS0ue+a5pcOaGUemM76VQ2JBttMfKGB0aSBzjCByzELMAkGA1UEBhMCVVMx
+EzARBgNVBAgTCkNhbGlmb3JuaWExEjAQBgNVBAcTCVN1bm55dmFsZTE9MDsGA1UE
+ChM0WE1MIFNlY3VyaXR5IExpYnJhcnkgKGh0dHA6Ly93d3cuYWxla3NleS5jb20v
+eG1sc2VjKTEZMBcGA1UECxMQUm9vdCBDZXJ0aWZpY2F0ZTEWMBQGA1UEAxMNQWxl
+a3NleSBTYW5pbjEhMB8GCSqGSIb3DQEJARYSeG1sc2VjQGFsZWtzZXkuY29tggEA
+MA0GCSqGSIb3DQEBBAUAA4GBALU/mzIxSv8vhDuomxFcplzwdlLZbvSQrfoNkMGY
+1UoS3YJrN+jZLWKSyWE3mIaPpElqXiXQGGkwD5iPQ1iJMbI7BeLvx6ZxX/f+c8Wn
+ss0uc1NxfahMaBoyG15IL4+beqO182fosaKJTrJNG3mc//ANGU9OsQM9mfBEt4oL
+NJ2D</X509Certificate>
+<X509SubjectName>emailAddress=xmlsec@aleksey.com,CN=Aleksey Sanin,OU=Examples RSA Certificate,O=XML Security Library (http://www.aleksey.com/xmlsec),ST=California,C=US</X509SubjectName>
+<X509SKI>JIQs8tRZIGKLLlyGkKOqMLonGpw=</X509SKI>
+</X509Data>
+</KeyInfo>
+</Signature></Envelope>

--- a/tests/examples/test_sign.py
+++ b/tests/examples/test_sign.py
@@ -222,6 +222,71 @@ def test_sign_generated_template_pem_with_x509_with_custom_ns():
     compare('sign4-res.xml', template)
 
 
+def test_sign_generated_template_pem_with_x509_with_cert_info():
+    """
+    Should sign a file using a dynamicaly created template, key from PEM
+    file and an X509 certificate.
+    """
+
+    # Load document file.
+    template = parse_xml('sign5-doc.xml')
+
+    # Create a signature template for RSA-SHA1 enveloped signature.
+    signature_node = xmlsec.template.create(
+        template,
+        xmlsec.Transform.EXCL_C14N,
+        xmlsec.Transform.RSA_SHA1)
+
+    assert signature_node is not None
+
+    # Add the <ds:Signature/> node to the document.
+    template.append(signature_node)
+
+    # Add the <ds:Reference/> node to the signature template.
+    ref = xmlsec.template.add_reference(signature_node, xmlsec.Transform.SHA1)
+
+    # Add the enveloped transform descriptor.
+    xmlsec.template.add_transform(ref, xmlsec.Transform.ENVELOPED)
+
+    # Add the <ds:KeyInfo/> and <ds:KeyName/> nodes.
+    key_info = xmlsec.template.ensure_key_info(signature_node)
+    x509_data = xmlsec.template.add_x509_data(key_info)
+    xmlsec.template.x509_data_add_subject_name(x509_data)
+    xmlsec.template.x509_data_add_certificate(x509_data)
+    xmlsec.template.x509_data_add_ski(x509_data)
+    x509_issuer_serial = xmlsec.template.x509_data_add_issuer_serial(x509_data)
+    xmlsec.template.x509_issuer_serial_add_issuer_name(x509_issuer_serial, 'Test Issuer')
+    xmlsec.template.x509_issuer_serial_add_serial_number(x509_issuer_serial, '1')
+
+    # Create a digital signature context (no key manager is needed).
+    ctx = xmlsec.SignatureContext()
+
+    # Load private key (assuming that there is no password).
+    filename = path.join(BASE_DIR, 'rsakey.pem')
+    key = xmlsec.Key.from_file(filename, xmlsec.KeyFormat.PEM)
+
+    assert key is not None
+
+    # Load the certificate and add it to the key.
+    filename = path.join(BASE_DIR, 'rsacert.pem')
+    key.load_cert_from_file(filename, xmlsec.KeyFormat.PEM)
+
+    # Set key name to the file name (note: this is just a test).
+    key.name = path.basename(filename)
+
+    # Set the key on the context.
+    ctx.key = key
+
+    assert ctx.key is not None
+    assert ctx.key.name == path.basename(filename)
+
+    # Sign the template.
+    ctx.sign(signature_node)
+
+    # Assert the contents of the XML document against the expected result.
+    compare('sign5-res.xml', template)
+
+
 def test_sign_binary():
     ctx = xmlsec.SignatureContext()
     filename = path.join(BASE_DIR, 'rsakey.pem')


### PR DESCRIPTION
I added the missing functions to work with X509 certificates when sign files.

This fix #25.