### PR TITLE
pkg-config required on mac for proper install

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -37,6 +37,6 @@ Mac
 
     xcode-select --install
     brew upgrade
-    brew install libxml2 libxmlsec1
+    brew install libxml2 libxmlsec1 pkg-config
     pip install xmlsec
 


### PR DESCRIPTION
(learnwell3) CJs-MacBook-Pro:learnwell cjwarren$ pip install xmlsec
Collecting xmlsec
  Using cached xmlsec-1.1.0.tar.gz
Requirement already satisfied: pkgconfig in /Users/cjwarren/.virtualenvs/learnwell3/lib/python3.5/site-packages (from xmlsec)
Requirement already satisfied: lxml>=3.0 in /Users/cjwarren/.virtualenvs/learnwell3/lib/python3.5/site-packages (from xmlsec)
Building wheels for collected packages: xmlsec
  Running setup.py bdist_wheel for xmlsec ... error
  Complete output from command /Users/cjwarren/.virtualenvs/learnwell3/bin/python3.5 -u -c "import setuptools, tokenize;__file__='/private/var/folders/5_/jg5kl6fj1p7gzrsfn7lnm_9c0000gn/T/pip-build-l19z_7fr/xmlsec/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /var/folders/5_/jg5kl6fj1p7gzrsfn7lnm_9c0000gn/T/tmp43waz_5zpip-wheel- --python-tag cp35:
  running bdist_wheel
  running build
  running build_ext
  error: pkg-config is not installed
  
  ----------------------------------------
  Failed building wheel for xmlsec
  Running setup.py clean for xmlsec
Failed to build xmlsec
Installing collected packages: xmlsec
  Running setup.py install for xmlsec ... error
    Complete output from command /Users/cjwarren/.virtualenvs/learnwell3/bin/python3.5 -u -c "import setuptools, tokenize;__file__='/private/var/folders/5_/jg5kl6fj1p7gzrsfn7lnm_9c0000gn/T/pip-build-l19z_7fr/xmlsec/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /var/folders/5_/jg5kl6fj1p7gzrsfn7lnm_9c0000gn/T/pip-nw5mysnk-record/install-record.txt --single-version-externally-managed --compile --install-headers /Users/cjwarren/.virtualenvs/learnwell3/bin/../include/site/python3.5/xmlsec:
    running install
    running build
    running build_ext
    error: pkg-config is not installed