### PR TITLE
Fix build on CentOS 6 w/ xmlsec1-1.2.19-3

### DIFF
--- a/xmlsec_setupinfo.py
+++ b/xmlsec_setupinfo.py
@@ -174,7 +174,7 @@ def load_xmlsec1_config():
         # fix macros, ensure that macros is list
         macros = list(config.get('define_macros', []))
         for i, v in enumerate(macros):
-            if v[0] == 'XMLSEC_CRYPTO':
+            if v[0] == 'XMLSEC_CRYPTO' and not (v[1].startswith('"') and v[1].endswith('"')):
                 macros[i] = ('XMLSEC_CRYPTO', '"{0}"'.format(v[1]))
                 break
         config['define_macros'] = macros


### PR DESCRIPTION
pkgconfig doesn't parse the XMLSEC_CRYPTO macro value correctly from xmlsec1-1.2.19-3 on CentOS 6: it comes already wrapped in quotes `"openssl"`, then xmlsec_setupinfo.py wraps it again `""openssl""`. So the gcc command ends up looking something like this:

```
gcc -DXMLSEC_CRYPTO=""openssl""  # ... other args ...
```

Which causes a syntax error when compiling main.c:
```
    /var/tmp/pip-qg0cd5lq-build/src/main.c: In function ‘PyXmlSec_Init’:
    /var/tmp/pip-qg0cd5lq-build/src/main.c:56: error: expected ‘,’ or ‘;’ before ‘openssl’
    error: command 'gcc' failed with exit status 1
```

The Changelog for [the xmlsec1 RPM](https://centos.pkgs.org/6/centos-x86_64/xmlsec1-1.2.20-4.el6.x86_64.rpm.html) suggests there's been some bugs with pkg-config that were fixed in later versions.

```
2014-05-28 - Simo Sorce <simo@redhat.com> - 1.2.20-2
- Update pkg-config fix patch to apply w/o fuzz

...

2014-05-23 - Simo Sorce <simo@redhat.com> - 1.2.19-6
- Fix incomplete patch

2014-05-23 - Simo Sorce <simo@redhat.com> - 1.2.19-5
- Add patch to deal with different behavior of pkg-config in RHEL6
```

This change just checks if XMLSEC_CRYPTO is already wrapped in quotes.