### PR TITLE
Sort input file list

### DIFF
--- a/xmlsec_setupinfo.py
+++ b/xmlsec_setupinfo.py
@@ -34,7 +34,7 @@ def description():
 
 
 def sources():
-    return glob.glob(os.path.join(get_base_dir(), "src", "*.c"))
+    return sorted(glob.glob(os.path.join(get_base_dir(), "src", "*.c")))
 
 
 def define_macros():


### PR DESCRIPTION
Sort input file list
so that `xmlsec.so` builds in a reproducible way
in spite of indeterministic filesystem readdir order
and http://bugs.python.org/issue30461

See https://reproducible-builds.org/ for why this is good.

This PR was done while working on reproducible builds for openSUSE.