### PR TITLE
Update lxml requirement to 3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pkgconfig
-lxml >= 3.0
+lxml >= 3.8.0


### PR DESCRIPTION
xmlsec will fail lxml versions prior to 3.8.0 with `ImportError: lxml.etree does not export expected C function adoptExternalDocument`