### PR TITLE
Add ubuntu to pre-install requirements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Depending on your OS, you may need to install the required native
 libraries first:
 
 Linux (Debian/Ubuntu)
-^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: bash
 

--- a/README.rst
+++ b/README.rst
@@ -46,12 +46,12 @@ Install
 Depending on your OS, you may need to install the required native
 libraries first:
 
-Linux (Debian)
+Linux (Debian/Ubuntu)
 ^^^^^^^^^^^^^^
 
 .. code-block:: bash
 
-   apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+   apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl pkg-config
 
 
 Note: There is no required version of LibXML2 for Ubuntu Precise,


### PR DESCRIPTION
I also added pkg-config because I assume that's necessary. That can be taken out if you want, the important part of this change is adding ubuntu

The reason behind this change is that I had a devil of a time trying to get xmlsec to work with using brew. See https://github.com/mehcode/python-xmlsec/issues/81#issuecomment-558876717. Hopefully this will let ubuntu users know they can just use apt, no need for brew.