### PR TITLE
Upload windows wheels to PyPI on tagged builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,7 @@
 environment:
     global:
-        TWINE_USERNAME:
-            secure: AIbDZTVaU3Ijr7mtxW7dlw==
+        TWINE_NON_INTERACTIVE: true
+        TWINE_USERNAME: __token__
         TWINE_PASSWORD:
             secure: YI+izt+hzh/czFuDCrne4XN78nQmT7jvcqe9uWvndqAUxhyXqr98GJ9FUSVPbqyWx+pW+5cKvh2PMdDEPJUcHMG8dtpHcosn3ndXnHGkHH3mwOnOduiUtrhlSEoIFwbZUhFRScYvfILGD8KM7RgcCiUUcner8QOFPiFX1zey8WVLynIj3c1rVe6Ola18pIUoL9D4NITNt5EWxexvr4vnkHmydk6dzWHBpiGsFujzccg+MoYN2ZjiN2JGSOykmEF/
     matrix:
@@ -32,7 +32,6 @@ build_script:
             $version = python -c "from setuptools_scm import get_version; print(get_version())"
         }
         $version | Set-Content version.txt
-    - python setup.py --version
     - python setup.py build bdist_wheel
     - ps: Get-ChildItem dist\*.whl | % { pip install $_.FullName }
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,15 +1,20 @@
-version: 1.3.{build}
-
 environment:
-  matrix:
-  - python: 27
-  - python: 27-x64
-  - python: 35
-  - python: 35-x64
-  - python: 36
-  - python: 36-x64
-  - python: 37
-  - python: 37-x64
+    global:
+        TWINE_USERNAME:
+            secure: AIbDZTVaU3Ijr7mtxW7dlw==
+        TWINE_PASSWORD:
+            secure: YI+izt+hzh/czFuDCrne4XN78nQmT7jvcqe9uWvndqAUxhyXqr98GJ9FUSVPbqyWx+pW+5cKvh2PMdDEPJUcHMG8dtpHcosn3ndXnHGkHH3mwOnOduiUtrhlSEoIFwbZUhFRScYvfILGD8KM7RgcCiUUcner8QOFPiFX1zey8WVLynIj3c1rVe6Ola18pIUoL9D4NITNt5EWxexvr4vnkHmydk6dzWHBpiGsFujzccg+MoYN2ZjiN2JGSOykmEF/
+    matrix:
+        - python: 27
+        - python: 27-x64
+        - python: 35
+        - python: 35-x64
+        - python: 36
+        - python: 36-x64
+        - python: 37
+        - python: 37-x64
+        - python: 38
+        - python: 38-x64
 
 install:
     - SET PATH=C:\\Python%PYTHON%;c:\\Python%PYTHON%\\scripts;%PATH%
@@ -23,9 +28,11 @@ build_script:
         If ($env:APPVEYOR_REPO_TAG -Eq "true" ) {
             $version = "$env:APPVEYOR_REPO_TAG_NAME"
         } Else {
-            $version = "$env:APPVEYOR_BUILD_VERSION.dev0"
+            pip install setuptools-scm
+            $version = python -c "from setuptools_scm import get_version; print(get_version())"
         }
         $version | Set-Content version.txt
+    - python setup.py --version
     - python setup.py build bdist_wheel
     - ps: Get-ChildItem dist\*.whl | % { pip install $_.FullName }
 
@@ -34,3 +41,12 @@ test_script:
     - pip list
     - py.test -v tests
     - ps: Get-ChildItem dist\*.whl | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+
+
+deploy: on
+deploy_script:
+    - ps: >-
+        If ($env:APPVEYOR_REPO_TAG -eq $TRUE) {
+            pip install twine
+            twine upload dist/*.whl
+        }

--- a/src/enc.c
+++ b/src/enc.c
@@ -169,6 +169,7 @@ ON_FAIL:
 
 // release the replaced nodes in a way safe for `lxml`
 static void PyXmlSec_ClearReplacedNodes(xmlSecEncCtxPtr ctx, PyXmlSec_LxmlDocumentPtr doc) {
+    PyXmlSec_LxmlElementPtr* elem;
     // release the replaced nodes in a way safe for `lxml`
     xmlNodePtr n = ctx->replacedNodeList;
     xmlNodePtr nn;
@@ -177,7 +178,7 @@ static void PyXmlSec_ClearReplacedNodes(xmlSecEncCtxPtr ctx, PyXmlSec_LxmlDocume
         PYXMLSEC_DEBUGF("clear replaced node %p", n);
         nn = n->next;
         // if n has references, it will not be deleted
-        PyXmlSec_LxmlElementPtr* elem = PyXmlSec_elementFactory(doc, n);
+        elem = PyXmlSec_elementFactory(doc, n);
         if (NULL == elem)
             xmlFreeNode(n);
         else


### PR DESCRIPTION
This PR adds automated upload of windows wheels from successful Appveyor jobs to PyPI.

Closes #88 #98 #101 #114 #118 #122 

Also, it directly addresses several issues in dependent package repos, e.g.

* onelogin/python3-saml#110
* onelogin/python3-saml#186
* onelogin/python3-saml#192

(maybe there's more of them)

Example of a [tagged build on Appveyor](https://ci.appveyor.com/project/hoefling/xmlsec/builds/32601395) and the resulting [version on TestPyPI](https://test.pypi.org/project/xmlsec/1.3.6.post2/).

@bgaifullin @mehcode if you decide to merge the PR, you have to replace the authentication token first. I have generated my own for a test upload, it won't work anymore for the real uploads. Go to your PyPI account, generate a new API token, encrypt it on Appveyor and replace the value of `TWINE_PASSWORD` env var in `.appveyor` config.

I am also willing to maintain the PyPI uploads if you want to, add me to project maintainers on PyPI and I will organize the rest.

----

To anyone with installation issues on Windows: you can use the wheels I have built to test the installation. Run
```sh
$ pip install xmlsec --extra-index-url=https://test.pypi.org/simple
```
This will install a version `1.3.6.post2` which isn't on PyPI, thus the special tag. The wheels are built from current master and are usable already, but I wouldn't rely on TestPyPI for the long run as it cleans up the uploaded packages once in a while.