### PR TITLE
Implement repr methods for __Transform and __KeyData classes, fix segfault when href attribute missing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,8 @@ addons:
     - pkg-config
     - lcov
 install:
-- travis_retry pip install coverage codecov -r requirements-test.txt
+- travis_retry pip install --upgrade pip setuptools wheel
+- travis_retry pip install coverage codecov -r requirements-test.txt --upgrade --force-reinstall
 - travis_retry pip install -e "."
 - pip list
 script: coverage run -m pytest -v tests

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,3 @@
 -r requirements.txt
 pytest>=4.6.9
+hypothesis

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,3 +14,6 @@ all_files  = 1
 
 [upload_docs]
 upload-dir = doc/build/html
+
+[flake8]
+max-line-length = 130

--- a/src/constants.c
+++ b/src/constants.c
@@ -22,7 +22,22 @@ static void PyXmlSec_Transform__del__(PyObject* self) {
 static PyObject* PyXmlSec_Transform__str__(PyObject* self) {
     char buf[300];
     PyXmlSec_Transform* transform = (PyXmlSec_Transform*)(self);
-    snprintf(buf, sizeof(buf), "%s, %s", transform->id->name, transform->id->href);
+    if (transform->id->href != NULL)
+        snprintf(buf, sizeof(buf), "%s, %s", transform->id->name, transform->id->href);
+    else
+        snprintf(buf, sizeof(buf), "%s, None", transform->id->name);
+
+    return PyString_FromString(buf);
+}
+
+// __repr__ method
+static PyObject* PyXmlSec_Transform__repr__(PyObject* self) {
+    char buf[300];
+    PyXmlSec_Transform* transform = (PyXmlSec_Transform*)(self);
+    if (transform->id->href != NULL)
+        snprintf(buf, sizeof(buf), "__Transform('%s', '%s', %d)", transform->id->name, transform->id->href, transform->id->usage);
+    else
+        snprintf(buf, sizeof(buf), "__Transform('%s', None, %d)", transform->id->name, transform->id->usage);
     return PyString_FromString(buf);
 }
 
@@ -33,7 +48,9 @@ static PyObject* PyXmlSec_TransformNameGet(PyXmlSec_Transform* self, void* closu
 
 static const char PyXmlSec_TransformHrefGet__doc__[] = "The transform's identification string (href).";
 static PyObject* PyXmlSec_TransformHrefGet(PyXmlSec_Transform* self, void* closure) {
-    return PyString_FromString((const char*)self->id->href);
+    if (self->id->href != NULL)
+        return PyString_FromString((const char*)self->id->href);
+    Py_RETURN_NONE;
 }
 
 static const char PyXmlSec_TransformUsageGet__doc__[] = "The allowed transforms usages.";
@@ -76,7 +93,7 @@ static PyTypeObject _PyXmlSec_TransformType = {
     0,                                              /* tp_getattr */
     0,                                              /* tp_setattr */
     0,                                              /* tp_reserved */
-    0,                                              /* tp_repr */
+    PyXmlSec_Transform__repr__,                     /* tp_repr */
     0,                                              /* tp_as_number */
     0,                                              /* tp_as_sequence */
     0,                                              /* tp_as_mapping */
@@ -128,7 +145,21 @@ static void PyXmlSec_KeyData__del__(PyObject* self) {
 static PyObject* PyXmlSec_KeyData__str__(PyObject* self) {
     char buf[300];
     PyXmlSec_KeyData* keydata = (PyXmlSec_KeyData*)(self);
-    snprintf(buf, sizeof(buf), "%s, %s", keydata->id->name, keydata->id->href);
+    if (keydata->id->href != NULL)
+        snprintf(buf, sizeof(buf), "%s, %s", keydata->id->name, keydata->id->href);
+    else
+        snprintf(buf, sizeof(buf), "%s, None", keydata->id->name);
+    return PyString_FromString(buf);
+}
+
+// __repr__ method
+static PyObject* PyXmlSec_KeyData__repr__(PyObject* self) {
+    char buf[300];
+    PyXmlSec_KeyData* keydata = (PyXmlSec_KeyData*)(self);
+    if (keydata->id->href != NULL)
+        snprintf(buf, sizeof(buf), "__KeyData('%s', '%s')", keydata->id->name, keydata->id->href);
+    else
+        snprintf(buf, sizeof(buf), "__KeyData('%s', None)", keydata->id->name);
     return PyString_FromString(buf);
 }
 
@@ -139,7 +170,9 @@ static PyObject* PyXmlSec_KeyDataNameGet(PyXmlSec_KeyData* self, void* closure) 
 
 static const char PyXmlSec_KeyDataHrefGet__doc__[] = "The key data's identification string (href).";
 static PyObject* PyXmlSec_KeyDataHrefGet(PyXmlSec_KeyData* self, void* closure) {
-    return PyString_FromString((const char*)self->id->href);
+    if (self->id->href != NULL)
+        return PyString_FromString((const char*)self->id->href);
+    Py_RETURN_NONE;
 }
 
 static PyGetSetDef PyXmlSec_KeyDataGetSet[] = {
@@ -170,7 +203,7 @@ static PyTypeObject _PyXmlSec_KeyDataType = {
     0,                                              /* tp_getattr */
     0,                                              /* tp_setattr */
     0,                                              /* tp_reserved */
-    0,                                              /* tp_repr */
+    PyXmlSec_KeyData__repr__,                       /* tp_repr */
     0,                                              /* tp_as_number */
     0,                                              /* tp_as_sequence */
     0,                                              /* tp_as_mapping */
@@ -394,7 +427,7 @@ int PyXmlSec_ConstantsModule_Init(PyObject* package) {
     PYXMLSEC_ADD_KEY_TYPE_CONSTANT(KeyDataTypePublic, "PUBLIC");
     PYXMLSEC_ADD_KEY_TYPE_CONSTANT(KeyDataTypePrivate, "PRIVATE");
     PYXMLSEC_ADD_KEY_TYPE_CONSTANT(KeyDataTypeSymmetric, "SYMMETRIC");
-    PYXMLSEC_ADD_KEY_TYPE_CONSTANT(KeyDataTypeSession, "SESSION");;
+    PYXMLSEC_ADD_KEY_TYPE_CONSTANT(KeyDataTypeSession, "SESSION");
     PYXMLSEC_ADD_KEY_TYPE_CONSTANT(KeyDataTypePermanent, "PERMANENT");
     PYXMLSEC_ADD_KEY_TYPE_CONSTANT(KeyDataTypeTrusted, "TRUSTED");
     PYXMLSEC_ADD_KEY_TYPE_CONSTANT(KeyDataTypeAny, "ANY");

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,0 +1,41 @@
+"""Test constants from :mod:`xmlsec.constants` module."""
+
+import xmlsec
+from hypothesis import given, strategies
+
+
+def _constants(typename):
+    return list(
+        sorted(
+            (
+                getattr(xmlsec.constants, name)
+                for name in dir(xmlsec.constants)
+                if type(getattr(xmlsec.constants, name)).__name__ == typename
+            ),
+            key=lambda t: t.name.lower(),
+        )
+    )
+
+
+@given(transform=strategies.sampled_from(_constants('__Transform')))
+def test_transform_str(transform):
+    """Test string representation of ``xmlsec.constants.__Transform``."""
+    assert str(transform) == '{}, {}'.format(transform.name, transform.href)
+
+
+@given(transform=strategies.sampled_from(_constants('__Transform')))
+def test_transform_repr(transform):
+    """Test raw string representation of ``xmlsec.constants.__Transform``."""
+    assert repr(transform) == '__Transform({!r}, {!r}, {})'.format(transform.name, transform.href, transform.usage)
+
+
+@given(keydata=strategies.sampled_from(_constants('__KeyData')))
+def test_keydata_str(keydata):
+    """Test string representation of ``xmlsec.constants.__KeyData``."""
+    assert str(keydata) == '{}, {}'.format(keydata.name, keydata.href)
+
+
+@given(keydata=strategies.sampled_from(_constants('__KeyData')))
+def test_keydata_repr(keydata):
+    """Test raw string representation of ``xmlsec.constants.__KeyData``."""
+    assert repr(keydata) == '__KeyData({!r}, {!r})'.format(keydata.name, keydata.href)


### PR DESCRIPTION
Some constants are missing `href`, see e.g. [xmlSecTransformRemoveXmlTagsC14NKlass](https://github.com/lsh123/xmlsec/blob/cd6fe1c19bd40e0e3bd63af61c34d595371e2bc9/src/c14n.c#L697).
Access to `href` thus ends in a segfault in Python:

```
import xmlsec

print(xmlsec.constants.TransformRemoveXmlTagsC14N.href)
```

This PR fixes that by returning `None` to avoid a null pointer.
