### PR TITLE
Add PEP 518 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,33 @@
+[tool.black]
+line_length = 130
+skip-string-normalization = true
+target_version = ['py38']
+include = '\.pyi?$'
+exclude = '''
+
+(
+  /(
+      \.eggs         # exclude a few common directories in the
+    | \.git          # root of the project
+    | \.mypy_cache
+    | \.tox
+    | build
+    | dist
+  )/
+)
+'''
+
+[tool.isort]
+force_alphabetical_sort_within_sections = true
+recursive = true
+line_length = 130
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+combine_as_imports = true
+known_first_party = ['xmlsec']
+known_third_party = ['lxml', 'pytest', '_pytest', 'hypothesis']
+
+[build-system]
+requires = ['setuptools>=42', 'wheel', 'setuptools_scm[toml]>=3.4']

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
-from setuptools import setup
-from setuptools import Extension
+from setuptools import Extension, setup
 from setuptools.command import build_ext
 
 import xmlsec_setupinfo
@@ -31,11 +30,11 @@ _xmlsec = Extension(
 
 setup(
     name=xmlsec_setupinfo.name(),
-    version=xmlsec_setupinfo.version(),
+    use_scm_version=True,
     description=xmlsec_setupinfo.description(),
     ext_modules=[_xmlsec],
     cmdclass={'build_ext': BuildExt},
-    setup_requires=xmlsec_setupinfo.requirements(),
+    setup_requires=xmlsec_setupinfo.requirements() + ['setuptools_scm[toml]>=3.4'],
     install_requires=xmlsec_setupinfo.requirements(),
     author="Bulat Gaifullin",
     author_email='support@mehcode.com',
@@ -58,6 +57,6 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
-        'Topic :: Text Processing :: Markup :: XML'
+        'Topic :: Text Processing :: Markup :: XML',
     ],
 )


### PR DESCRIPTION
Also use `setuptools-scm` for version calculations. This allows to use Git tags as the single source of truth for version calculations: on tagged commit, the tag version is used, otherwise, the version is calculated from `git describe --tags` info.