### PR TITLE
Record coverage in test runs on travis, generate codecov report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,12 @@ matrix:
   - python: 3.8
     dist: xenial
     sudo: required
+env:
+  global:
+  - CFLAGS=-coverage
+  - LDFLAGS=-coverage -lgcov
+  - PYXMLSEC_TEST_ITERATIONS=50
+
 addons:
   apt:
     packages:
@@ -23,11 +29,16 @@ addons:
     - libxmlsec1-openssl
     - libxslt1-dev
     - pkg-config
+    - lcov
 install:
-- travis_retry pip install -r requirements-test.txt
+- travis_retry pip install coverage codecov -r requirements-test.txt
 - travis_retry pip install -e "."
 - pip list
-script: py.test -v tests
+script: coverage run -m pytest -v tests
+after_success:
+- lcov --capture --directory . --output-file coverage.info
+- lcov --list coverage.info
+- codecov --file coverage.info
 before_deploy:
 - travis_retry pip install Sphinx
 - python setup.py build_sphinx

--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,8 @@ python-xmlsec
     :target: https://travis-ci.org/mehcode/python-xmlsec
 .. image:: https://ci.appveyor.com/api/projects/status/20rtt2wv96gag9cy?svg=true
     :target: https://ci.appveyor.com/project/bgaifullin/python-xmlsec
+.. image:: https://codecov.io/gh/mehcode/python-xmlsec/branch/master/graph/badge.svg
+    :target: https://codecov.io/gh/mehcode/python-xmlsec
 .. image:: https://img.shields.io/pypi/v/xmlsec.svg
     :target: https://pypi.python.org/pypi/xmlsec
 .. image:: https://img.shields.io/badge/docs-latest-green.svg


### PR DESCRIPTION
This is helpful to determine untested code and adds to project's overall health. Codecov also offers a bot that determines whether a PR decreases code coverage which I've always very convenient to have for reviews.