### PR TITLE
add source and documentation urls to package metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -442,6 +442,7 @@ setup(
     maintainer='Oleg Hoefling',
     maintainer_email='oleg.hoefling@gmail.com',
     url='https://github.com/mehcode/python-xmlsec',
+    project_urls={'Documentation': 'https://xmlsec.readthedocs.io', 'Source': 'https://github.com/mehcode/python-xmlsec',},
     license='MIT',
     keywords=['xmlsec'],
     classifiers=[


### PR DESCRIPTION
This provides nice URLs to RTD and Github in the "Project links" section on PyPI:

![image](https://user-images.githubusercontent.com/4455652/82802411-22cb3780-9e7f-11ea-8514-ab7c5d6e88e1.png)

Signed-off-by: oleg.hoefling <oleg.hoefling@gmail.com>