### PR TITLE
Fix xmlsec version comparison macro

### DIFF
--- a/src/constants.c
+++ b/src/constants.c
@@ -452,7 +452,8 @@ int PyXmlSec_ConstantsModule_Init(PyObject* package) {
 #ifndef XMLSEC_NO_DSA
     PYXMLSEC_ADD_KEYDATA_CONSTANT(KeyDataDsa, "DSA")
 #endif
-#if XMLSEC_VERSION_HEX > 306
+#if XMLSEC_VERSION_HEX > 0x10212
+    // from version 1.2.19
     PYXMLSEC_ADD_KEYDATA_CONSTANT(KeyDataEcdsa, "ECDSA")
 #endif
     PYXMLSEC_ADD_KEYDATA_CONSTANT(KeyDataHmac, "HMAC")
@@ -502,7 +503,8 @@ int PyXmlSec_ConstantsModule_Init(PyObject* package) {
     PYXMLSEC_ADD_TRANSFORM_CONSTANT(TransformDsaSha1, "DSA_SHA1");
 #endif
 
-#if XMLSEC_VERSION_HEX > 306
+#if XMLSEC_VERSION_HEX > 0x10212
+    // from version 1.2.19
     PYXMLSEC_ADD_TRANSFORM_CONSTANT(TransformEcdsaSha1, "ECDSA_SHA1");
     PYXMLSEC_ADD_TRANSFORM_CONSTANT(TransformEcdsaSha224, "ECDSA_SHA224");
     PYXMLSEC_ADD_TRANSFORM_CONSTANT(TransformEcdsaSha256, "ECDSA_SHA256");
@@ -543,7 +545,8 @@ int PyXmlSec_ConstantsModule_Init(PyObject* package) {
     PYXMLSEC_ADD_TRANSFORM_CONSTANT(TransformSha384, "SHA384");
     PYXMLSEC_ADD_TRANSFORM_CONSTANT(TransformSha512, "SHA512");
 
-#if XMLSEC_VERSION_HEX > 315
+#if XMLSEC_VERSION_HEX > 0x1021B
+    // from version 1.2.28
     PYXMLSEC_ADD_TRANSFORM_CONSTANT(TransformAes128Gcm, "AES128_GCM");
     PYXMLSEC_ADD_TRANSFORM_CONSTANT(TransformAes192Gcm, "AES192_GCM");
     PYXMLSEC_ADD_TRANSFORM_CONSTANT(TransformAes256Gcm, "AES256_GCM");

--- a/src/main.c
+++ b/src/main.c
@@ -27,7 +27,7 @@ static int free_mode = _PYXMLSEC_FREE_NONE;
 
 #ifndef XMLSEC_NO_CRYPTO_DYNAMIC_LOADING
 static const xmlChar* PyXmlSec_GetCryptoLibName() {
-#if XMLSEC_VERSION_HEX > 308
+#if XMLSEC_VERSION_HEX > 0x10214
     // xmlSecGetDefaultCrypto was introduced in version 1.2.21
     const xmlChar* cryptoLib = xmlSecGetDefaultCrypto();
 #else

--- a/src/platform.h
+++ b/src/platform.h
@@ -19,11 +19,11 @@
 #include <windows.h>
 #endif /* MS_WIN32 */
 
-#define XMLSEC_VERSION_HEX ((XMLSEC_VERSION_MAJOR << 8) | (XMLSEC_VERSION_MINOR << 4) | (XMLSEC_VERSION_SUBMINOR))
+#define XMLSEC_VERSION_HEX ((XMLSEC_VERSION_MAJOR << 16) | (XMLSEC_VERSION_MINOR << 8) | (XMLSEC_VERSION_SUBMINOR))
 
 // XKMS support was removed in version 1.2.21
 // https://mail.gnome.org/archives/commits-list/2015-February/msg10555.html
-#if  XMLSEC_VERSION_HEX > 0x134
+#if  XMLSEC_VERSION_HEX > 0x10214
 #define XMLSEC_NO_XKMS 1
 #endif
 


### PR DESCRIPTION
Use 8 instead of 4 bits for all xmlsec version fields in version comparison macro to prevent compilation errors starting from xmlsec version 1.2.32

Closes #165