### PR TITLE
End Python 2.7 support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - python: 27
-  - python: 27-x64
   - python: 35
   - python: 35-x64
   - python: 36

--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -17,28 +17,28 @@ jobs:
           pip install --upgrade pip setuptools wheel
           brew install libxml2 libxmlsec1 pkg-config
       - name: Build macosx_x86_64 wheel
-        run: |
-          python setup.py bdist_wheel
-      - name: Set environment variables
-        shell: bash
-        run: |
-          echo ::set-env name=PKGVER::$(python setup.py --version)
-          echo ::set-env name=LLVM_PROFILE_FILE::"pyxmlsec-%p.profraw"
-      - name: Install test dependencies
         env:
           CC: clang
           CFLAGS: "-fprofile-instr-generate -fcoverage-mapping"
           LDFLAGS: "-fprofile-instr-generate -fcoverage-mapping"
         run: |
+          python setup.py bdist_wheel
           rm -rf build/
+      - name: Set environment variables
+        shell: bash
+        run: |
+          echo "PKGVER=$(python setup.py --version)" >> $GITHUB_ENV
+          echo "LLVM_PROFILE_FILE=pyxmlsec.profraw" >> $GITHUB_ENV
+      - name: Install test dependencies
+        run: |
           pip install coverage --upgrade -r requirements-test.txt
           pip install xmlsec --only-binary=xmlsec --no-index --find-links=dist/
+          echo "PYXMLSEC_LIBFILE=$(python -c 'import xmlsec; print(xmlsec.__file__)')" >> $GITHUB_ENV
       - name: Run tests
         run: |
           coverage run -m pytest -v --color=yes
       - name: Report coverage to codecov
         run: |
-          LIBFILE=$(python -c "import xmlsec; print(xmlsec.__file__)")
-          /Library/Developer/CommandLineTools/usr/bin/llvm-profdata merge -sparse pyxmlsec-*.profraw -output pyxmlsec.profdata
-          /Library/Developer/CommandLineTools/usr/bin/llvm-cov show ${LIBFILE} -instr-profile=pyxmlsec.profdata src > coverage.txt
+          /Library/Developer/CommandLineTools/usr/bin/llvm-profdata merge -sparse ${{ env.LLVM_PROFILE_FILE }} -output pyxmlsec.profdata
+          /Library/Developer/CommandLineTools/usr/bin/llvm-cov show ${{ env.PYXMLSEC_LIBFILE }} -instr-profile=pyxmlsec.profdata src > coverage.txt
           bash <(curl -s https://codecov.io/bash) -f coverage.txt

--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
+        python: [3.5, 3.6, 3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v1
       - name: Setup Python

--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           rm -rf build/
           pip install coverage --upgrade -r requirements-test.txt
-          pip install --editable .
+          pip install xmlsec --only-binary=xmlsec --no-index --find-links=dist/
       - name: Run tests
         run: |
           coverage run -m pytest -v --color=yes

--- a/.github/workflows/manylinux2010.yml
+++ b/.github/workflows/manylinux2010.yml
@@ -6,7 +6,7 @@ jobs:
     container: quay.io/pypa/manylinux2010_x86_64
     strategy:
       matrix:
-        python-abi: [cp27-cp27m, cp27-cp27mu, cp35-cp35m, cp36-cp36m, cp37-cp37m, cp38-cp38, cp39-cp39]
+        python-abi: [cp35-cp35m, cp36-cp36m, cp37-cp37m, cp38-cp38, cp39-cp39]
     steps:
       - uses: actions/checkout@v1
       - name: Install build dependencies

--- a/.github/workflows/manylinux2010.yml
+++ b/.github/workflows/manylinux2010.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set environment variables
         shell: bash
         run: |
-          echo ::set-env name=PKGVER::$(/opt/python/${{ matrix.python-abi }}/bin/python setup.py --version)
+          echo "PKGVER=$(/opt/python/${{ matrix.python-abi }}/bin/python setup.py --version)" >> $GITHUB_ENV
       - name: Build linux_x86_64 wheel
         env:
           PYXMLSEC_STATIC_DEPS: true
@@ -24,10 +24,10 @@ jobs:
       - name: Label manylinux2010_x86_64 wheel
         run: |
           ls -la dist/
-          auditwheel show dist/xmlsec-${PKGVER}-${{ matrix.python-abi }}-linux_x86_64.whl
-          auditwheel repair dist/xmlsec-${PKGVER}-${{ matrix.python-abi }}-linux_x86_64.whl
+          auditwheel show dist/xmlsec-${{ env.PKGVER }}-${{ matrix.python-abi }}-linux_x86_64.whl
+          auditwheel repair dist/xmlsec-${{ env.PKGVER }}-${{ matrix.python-abi }}-linux_x86_64.whl
           ls -l wheelhouse/
-          auditwheel show wheelhouse/xmlsec-${PKGVER}-${{ matrix.python-abi }}-manylinux2010_x86_64.whl
+          auditwheel show wheelhouse/xmlsec-${{ env.PKGVER }}-${{ matrix.python-abi }}-manylinux2010_x86_64.whl
       - name: Install test dependencies
         run: |
           /opt/python/${{ matrix.python-abi }}/bin/pip install --upgrade -r requirements-test.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,8 @@ addons:
 install:
 - travis_retry pip install --upgrade pip setuptools wheel
 - travis_retry pip install coverage -r requirements-test.txt --upgrade --force-reinstall
-- travis_retry pip install -e "."
-- pip list
+- python setup.py bdist_wheel
+- pip install xmlsec --only-binary=xmlsec --no-index --find-links=dist/
 script: coverage run -m pytest -v tests --color=yes
 after_success:
 - lcov --capture --no-external --directory . --output-file coverage.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ notifications:
   email: false
 matrix:
   include:
-  - python: 2.7
   - python: 3.5
   - python: 3.6
   - python: 3.7

--- a/setup.py
+++ b/setup.py
@@ -7,15 +7,11 @@ import tarfile
 import zipfile
 from distutils import log
 from distutils.errors import DistutilsError
+from pathlib import Path
+from urllib.request import urlcleanup, urljoin, urlretrieve
 
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext as build_ext_orig
-
-if sys.version_info >= (3, 4):
-    from urllib.request import urlcleanup, urljoin, urlretrieve
-else:
-    from urllib import urlcleanup, urlretrieve
-    from urlparse import urljoin
 
 
 class build_ext(build_ext_orig, object):
@@ -23,11 +19,6 @@ class build_ext(build_ext_orig, object):
         self.announce(message, level=log.INFO)
 
     def run(self):
-        if sys.version_info >= (3, 4):
-            from pathlib import Path
-        else:
-            from pathlib2 import Path
-
         ext = self.ext_map['xmlsec']
         self.debug = os.environ.get('PYXMLSEC_ENABLE_DEBUG', False)
         self.static = os.environ.get('PYXMLSEC_STATIC_DEPS', False)
@@ -107,16 +98,10 @@ class build_ext(build_ext_orig, object):
 
     def prepare_static_build_win(self):
         release_url = 'https://github.com/bgaifullin/libxml2-win-binaries/releases/download/v2018.08/'
-        if sys.version_info < (3, 5):
-            if sys.maxsize > 2147483647:
-                suffix = 'vs2008.win64'
-            else:
-                suffix = "vs2008.win32"
+        if sys.maxsize > 2147483647:
+            suffix = 'win64'
         else:
-            if sys.maxsize > 2147483647:
-                suffix = "win64"
-            else:
-                suffix = "win32"
+            suffix = 'win32'
 
         libs = [
             'libxml2-2.9.4.{}.zip'.format(suffix),
@@ -185,7 +170,7 @@ class build_ext(build_ext_orig, object):
         self.libxml2_version = os.environ.get('PYXMLSEC_LIBXML2_VERSION', None)
         self.libxslt_version = os.environ.get('PYXMLSEC_LIBXLST_VERSION', None)
         self.zlib_version = os.environ.get('PYXMLSEC_ZLIB_VERSION', '1.2.11')
-        self.xmlsec1_version = os.environ.get('PYXMLSEC_XMLSEC1_VERSION', '1.2.30')
+        self.xmlsec1_version = os.environ.get('PYXMLSEC_XMLSEC1_VERSION', '1.2.31')
 
         self.info('Settings:')
         self.info('{:20} {}'.format('Lib sources in:', self.libs_dir.absolute()))
@@ -402,25 +387,10 @@ class build_ext(build_ext_orig, object):
         ext.extra_objects = [str(self.prefix_dir / 'lib' / o) for o in extra_objects]
 
 
-if sys.version_info >= (3, 4):
-    from pathlib import Path
-
-    src_root = Path(__file__).parent / 'src'
-    sources = [str(p.absolute()) for p in src_root.rglob('*.c')]
-else:
-    import fnmatch
-
-    src_root = os.path.join(os.path.dirname(__file__), 'src')
-    sources = []
-    for root, _, files in os.walk(src_root):
-        for file in fnmatch.filter(files, '*.c'):
-            sources.append(os.path.join(root, file))
-
+src_root = Path(__file__).parent / 'src'
+sources = [str(p.absolute()) for p in src_root.rglob('*.c')]
 pyxmlsec = Extension('xmlsec', sources=sources)
 setup_reqs = ['setuptools_scm[toml]>=3.4', 'pkgconfig>=1.5.1', 'lxml>=3.8']
-
-if sys.version_info < (3, 4):
-    setup_reqs.append('pathlib2')
 
 
 with io.open('README.rst', encoding='utf-8') as f:
@@ -434,7 +404,7 @@ setup(
     long_description=long_desc,
     ext_modules=[pyxmlsec],
     cmdclass={'build_ext': build_ext},
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
+    python_requires='>=3.5',
     setup_requires=setup_reqs,
     install_requires=['lxml>=3.8'],
     author="Bulat Gaifullin",
@@ -442,7 +412,10 @@ setup(
     maintainer='Oleg Hoefling',
     maintainer_email='oleg.hoefling@gmail.com',
     url='https://github.com/mehcode/python-xmlsec',
-    project_urls={'Documentation': 'https://xmlsec.readthedocs.io', 'Source': 'https://github.com/mehcode/python-xmlsec',},
+    project_urls={
+        'Documentation': 'https://xmlsec.readthedocs.io',
+        'Source': 'https://github.com/mehcode/python-xmlsec',
+    },
     license='MIT',
     keywords=['xmlsec'],
     classifiers=[
@@ -452,12 +425,12 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: C',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Text Processing :: Markup :: XML',
         'Typing :: Typed',
     ],


### PR DESCRIPTION
[Python 2.7 has reached EOL on 1st Jan 2020](https://www.python.org/doc/sunset-python-2/), and with the CI services not offering the necessary infrastructure, supporting it has got very tedious. This PR removes 2.7 from the CI pipeline.