### PR TITLE
Remove Python 2 compatibility code

### DIFF
--- a/src/constants.c
+++ b/src/constants.c
@@ -245,7 +245,6 @@ static PyObject* PyXmlSec_KeyDataNew(xmlSecKeyDataId id) {
     return (PyObject*)keydata;
 }
 
-#ifdef PY3K
 static PyModuleDef PyXmlSec_ConstantsModule =
 {
     PyModuleDef_HEAD_INIT,
@@ -253,7 +252,6 @@ static PyModuleDef PyXmlSec_ConstantsModule =
     PYXMLSEC_CONSTANTS_DOC,
     -1, NULL, NULL, NULL, NULL, NULL
 };
-#endif  // PY3K
 
 // initialize constants module and registers it base package
 int PyXmlSec_ConstantsModule_Init(PyObject* package) {
@@ -267,12 +265,7 @@ int PyXmlSec_ConstantsModule_Init(PyObject* package) {
     PyObject* keyDataTypeCls = NULL;
     PyObject* tmp = NULL;
 
-#ifdef PY3K
     constants = PyModule_Create(&PyXmlSec_ConstantsModule);
-#else
-    constants = Py_InitModule3(STRINGIFY(MODULE_NAME) ".constants", NULL, PYXMLSEC_CONSTANTS_DOC);
-    Py_XINCREF(constants);
-#endif
 
     if (!constants) return -1;
 

--- a/src/constants.c
+++ b/src/constants.c
@@ -292,7 +292,7 @@ int PyXmlSec_ConstantsModule_Init(PyObject* package) {
 #undef PYXMLSEC_ADD_INT_CONSTANT
 
 #define PYXMLSEC_DECLARE_NAMESPACE(var, name) \
-    if (!(var = PyCreateDummyObject(name))) goto ON_FAIL; \
+    if (!(var = PyModule_New(name))) goto ON_FAIL; \
     if (PyModule_AddObject(package, name, var) < 0) goto ON_FAIL; \
     Py_INCREF(var); // add object steels reference
 

--- a/src/constants.c
+++ b/src/constants.c
@@ -27,7 +27,7 @@ static PyObject* PyXmlSec_Transform__str__(PyObject* self) {
     else
         snprintf(buf, sizeof(buf), "%s, None", transform->id->name);
 
-    return PyString_FromString(buf);
+    return PyUnicode_FromString(buf);
 }
 
 // __repr__ method
@@ -38,18 +38,18 @@ static PyObject* PyXmlSec_Transform__repr__(PyObject* self) {
         snprintf(buf, sizeof(buf), "__Transform('%s', '%s', %d)", transform->id->name, transform->id->href, transform->id->usage);
     else
         snprintf(buf, sizeof(buf), "__Transform('%s', None, %d)", transform->id->name, transform->id->usage);
-    return PyString_FromString(buf);
+    return PyUnicode_FromString(buf);
 }
 
 static const char PyXmlSec_TransformNameGet__doc__[] = "The transform's name.";
 static PyObject* PyXmlSec_TransformNameGet(PyXmlSec_Transform* self, void* closure) {
-    return PyString_FromString((const char*)self->id->name);
+    return PyUnicode_FromString((const char*)self->id->name);
 }
 
 static const char PyXmlSec_TransformHrefGet__doc__[] = "The transform's identification string (href).";
 static PyObject* PyXmlSec_TransformHrefGet(PyXmlSec_Transform* self, void* closure) {
     if (self->id->href != NULL)
-        return PyString_FromString((const char*)self->id->href);
+        return PyUnicode_FromString((const char*)self->id->href);
     Py_RETURN_NONE;
 }
 
@@ -149,7 +149,7 @@ static PyObject* PyXmlSec_KeyData__str__(PyObject* self) {
         snprintf(buf, sizeof(buf), "%s, %s", keydata->id->name, keydata->id->href);
     else
         snprintf(buf, sizeof(buf), "%s, None", keydata->id->name);
-    return PyString_FromString(buf);
+    return PyUnicode_FromString(buf);
 }
 
 // __repr__ method
@@ -160,18 +160,18 @@ static PyObject* PyXmlSec_KeyData__repr__(PyObject* self) {
         snprintf(buf, sizeof(buf), "__KeyData('%s', '%s')", keydata->id->name, keydata->id->href);
     else
         snprintf(buf, sizeof(buf), "__KeyData('%s', None)", keydata->id->name);
-    return PyString_FromString(buf);
+    return PyUnicode_FromString(buf);
 }
 
 static const char PyXmlSec_KeyDataNameGet__doc__[] = "The key data's name.";
 static PyObject* PyXmlSec_KeyDataNameGet(PyXmlSec_KeyData* self, void* closure) {
-    return PyString_FromString((const char*)self->id->name);
+    return PyUnicode_FromString((const char*)self->id->name);
 }
 
 static const char PyXmlSec_KeyDataHrefGet__doc__[] = "The key data's identification string (href).";
 static PyObject* PyXmlSec_KeyDataHrefGet(PyXmlSec_KeyData* self, void* closure) {
     if (self->id->href != NULL)
-        return PyString_FromString((const char*)self->id->href);
+        return PyUnicode_FromString((const char*)self->id->href);
     Py_RETURN_NONE;
 }
 
@@ -308,7 +308,7 @@ int PyXmlSec_ConstantsModule_Init(PyObject* package) {
 
 
 #define PYXMLSEC_ADD_NS_CONSTANT(name, lname) \
-    tmp = PyString_FromString((const char*)(JOIN(xmlSec, name))); \
+    tmp = PyUnicode_FromString((const char*)(JOIN(xmlSec, name))); \
     PYXMLSEC_ADD_CONSTANT(nsCls, name, lname);
 
     // namespaces
@@ -334,7 +334,7 @@ int PyXmlSec_ConstantsModule_Init(PyObject* package) {
 
 
 #define PYXMLSEC_ADD_ENC_CONSTANT(name, lname) \
-    tmp = PyString_FromString((const char*)(JOIN(xmlSec, name))); \
+    tmp = PyUnicode_FromString((const char*)(JOIN(xmlSec, name))); \
     PYXMLSEC_ADD_CONSTANT(encryptionTypeCls, name, lname);
 
     // encryption type
@@ -349,7 +349,7 @@ int PyXmlSec_ConstantsModule_Init(PyObject* package) {
 
 
 #define PYXMLSEC_ADD_NODE_CONSTANT(name, lname) \
-    tmp = PyString_FromString((const char*)(JOIN(xmlSec, name))); \
+    tmp = PyUnicode_FromString((const char*)(JOIN(xmlSec, name))); \
     PYXMLSEC_ADD_CONSTANT(nodeCls, name, lname);
 
     // node

--- a/src/keys.c
+++ b/src/keys.c
@@ -460,7 +460,7 @@ static int PyXmlSec_KeyNameSet(PyObject* self, PyObject* value, void* closure) {
         return 0;
     }
 
-    name = PyString_AsString(value);
+    name = PyUnicode_AsUTF8(value);
     if (name == NULL) return -1;
 
     if (xmlSecKeySetName(key->handle, XSTR(name)) < 0) {

--- a/src/keys.c
+++ b/src/keys.c
@@ -436,7 +436,7 @@ static PyObject* PyXmlSec_KeyNameGet(PyObject* self, void* closure) {
     }
     cname = (const char*)xmlSecKeyGetName(key->handle);
     if (cname != NULL) {
-        return PyString_FromString(cname);
+        return PyUnicode_FromString(cname);
     }
     Py_RETURN_NONE;
 }

--- a/src/keys.c
+++ b/src/keys.c
@@ -249,7 +249,7 @@ static PyObject* PyXmlSec_KeyFromBinaryFile(PyObject* self, PyObject* args, PyOb
 
     PYXMLSEC_DEBUG("load symmetric key - start");
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O!O&:from_binary_file", kwlist,
-        PyXmlSec_KeyDataType, &keydata,  PyString_FSConverter, &filepath))
+        PyXmlSec_KeyDataType, &keydata, PyUnicode_FSConverter, &filepath))
     {
         goto ON_FAIL;
     }
@@ -698,7 +698,7 @@ static PyObject* PyXmlSec_KeysManagerLoadCert(PyObject* self, PyObject* args, Py
 
     PYXMLSEC_DEBUGF("%p: load cert - start", self);
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O&II:load_cert", kwlist,
-        PyString_FSConverter, &filepath, &format, &type)) {
+        PyUnicode_FSConverter, &filepath, &format, &type)) {
         goto ON_FAIL;
     }
 

--- a/src/platform.h
+++ b/src/platform.h
@@ -37,7 +37,6 @@ typedef int Py_ssize_t;
 
 #if PY_MAJOR_VERSION >= 3
 #define PY3K 1
-#define PyString_Check PyUnicode_Check
 #define PyString_FromStringAndSize PyUnicode_FromStringAndSize
 
 #define PyString_AsString PyUnicode_AsUTF8
@@ -48,7 +47,6 @@ typedef int Py_ssize_t;
 #define PyString_FSConverter PyUnicode_FSConverter
 #else // PY3K
 
-#define PyBytes_Check PyString_Check
 #define PyBytes_FromStringAndSize PyString_FromStringAndSize
 
 #define PyBytes_AsString PyString_AsString

--- a/src/platform.h
+++ b/src/platform.h
@@ -37,25 +37,16 @@ typedef int Py_ssize_t;
 
 #if PY_MAJOR_VERSION >= 3
 #define PY3K 1
-#define PyString_FromStringAndSize PyUnicode_FromStringAndSize
 
 #define PyString_AsString PyUnicode_AsUTF8
-#define PyString_AsUtf8AndSize PyUnicode_AsUTF8AndSize
 
 #define PyCreateDummyObject PyModule_New
 
 #define PyString_FSConverter PyUnicode_FSConverter
 #else // PY3K
 
-#define PyBytes_FromStringAndSize PyString_FromStringAndSize
-
 #define PyBytes_AsString PyString_AsString
 #define PyBytes_AsStringAndSize PyString_AsStringAndSize
-
-static inline char* PyString_AsUtf8AndSize(PyObject *obj, Py_ssize_t* length) {
-    char* buffer = NULL;
-    return (PyString_AsStringAndSize(obj, &buffer, length) < 0) ? (char*)(0) : buffer;
-}
 
 static inline PyObject* PyCreateDummyObject(const char* name) {
     PyObject* tmp = Py_InitModule(name, NULL);

--- a/src/platform.h
+++ b/src/platform.h
@@ -38,18 +38,10 @@ typedef int Py_ssize_t;
 #if PY_MAJOR_VERSION >= 3
 #define PY3K 1
 
-#define PyCreateDummyObject PyModule_New
-
 #define PyString_FSConverter PyUnicode_FSConverter
 #else // PY3K
 
 #define PyBytes_AsStringAndSize PyString_AsStringAndSize
-
-static inline PyObject* PyCreateDummyObject(const char* name) {
-    PyObject* tmp = Py_InitModule(name, NULL);
-    Py_INCREF(tmp);
-    return tmp;
-}
 
 static inline int PyString_FSConverter(PyObject* o, PyObject** p) {
     if (o == NULL) {

--- a/src/platform.h
+++ b/src/platform.h
@@ -37,21 +37,9 @@ typedef int Py_ssize_t;
 
 #if PY_MAJOR_VERSION >= 3
 #define PY3K 1
-
-#define PyString_FSConverter PyUnicode_FSConverter
 #else // PY3K
 
 #define PyBytes_AsStringAndSize PyString_AsStringAndSize
-
-static inline int PyString_FSConverter(PyObject* o, PyObject** p) {
-    if (o == NULL) {
-        return 0;
-    }
-
-    Py_INCREF(o);
-    *p = o;
-    return 1;
-}
 
 #endif // PYTHON3
 

--- a/src/platform.h
+++ b/src/platform.h
@@ -35,14 +35,6 @@ typedef int Py_ssize_t;
 #define PY_SSIZE_T_MIN INT_MIN
 #endif
 
-#if PY_MAJOR_VERSION >= 3
-#define PY3K 1
-#else // PY3K
-
-#define PyBytes_AsStringAndSize PyString_AsStringAndSize
-
-#endif // PYTHON3
-
 static inline char* PyBytes_AsStringAndSize2(PyObject *obj, Py_ssize_t* length) {
     char* buffer = NULL;
     return ((PyBytes_AsStringAndSize(obj, &buffer, length) < 0) ? (char*)(0) : buffer);

--- a/src/platform.h
+++ b/src/platform.h
@@ -40,8 +40,6 @@ typedef int Py_ssize_t;
 #define PyString_Check PyUnicode_Check
 #define PyString_FromStringAndSize PyUnicode_FromStringAndSize
 
-#define PyString_FromString PyUnicode_FromString
-
 #define PyString_AsString PyUnicode_AsUTF8
 #define PyString_AsUtf8AndSize PyUnicode_AsUTF8AndSize
 

--- a/src/platform.h
+++ b/src/platform.h
@@ -38,14 +38,11 @@ typedef int Py_ssize_t;
 #if PY_MAJOR_VERSION >= 3
 #define PY3K 1
 
-#define PyString_AsString PyUnicode_AsUTF8
-
 #define PyCreateDummyObject PyModule_New
 
 #define PyString_FSConverter PyUnicode_FSConverter
 #else // PY3K
 
-#define PyBytes_AsString PyString_AsString
 #define PyBytes_AsStringAndSize PyString_AsStringAndSize
 
 static inline PyObject* PyCreateDummyObject(const char* name) {

--- a/src/template.c
+++ b/src/template.c
@@ -766,7 +766,7 @@ static PyObject* PyXmlSec_TemplateTransformAddC14NInclNamespaces(PyObject* self,
         goto ON_FAIL;
     }
     if (PyList_Check(prefixes) || PyTuple_Check(prefixes)) {
-        sep = PyString_FromString(" ");
+        sep = PyUnicode_FromString(" ");
         prefixes = PyObject_CallMethod(sep, "join", "O", prefixes);
         Py_DECREF(sep);
     } else if (PyString_Check(prefixes)) {

--- a/src/template.c
+++ b/src/template.c
@@ -781,7 +781,7 @@ static PyObject* PyXmlSec_TemplateTransformAddC14NInclNamespaces(PyObject* self,
     }
 
 
-    c_prefixes = PyString_AsString(prefixes);
+    c_prefixes = PyUnicode_AsUTF8(prefixes);
     Py_BEGIN_ALLOW_THREADS;
     res = xmlSecTmplTransformAddC14NInclNamespaces(node->_c_node, XSTR(c_prefixes));
     Py_END_ALLOW_THREADS;

--- a/src/template.c
+++ b/src/template.c
@@ -769,7 +769,7 @@ static PyObject* PyXmlSec_TemplateTransformAddC14NInclNamespaces(PyObject* self,
         sep = PyUnicode_FromString(" ");
         prefixes = PyObject_CallMethod(sep, "join", "O", prefixes);
         Py_DECREF(sep);
-    } else if (PyString_Check(prefixes)) {
+    } else if (PyUnicode_Check(prefixes)) {
         Py_INCREF(prefixes);
     } else {
         PyErr_SetString(PyExc_TypeError, "expected instance of str or list of str");

--- a/src/template.c
+++ b/src/template.c
@@ -918,7 +918,6 @@ static PyMethodDef PyXmlSec_TemplateMethods[] = {
     {NULL, NULL} /* sentinel */
 };
 
-#ifdef PY3K
 static PyModuleDef PyXmlSec_TemplateModule =
 {
     PyModuleDef_HEAD_INIT,
@@ -931,15 +930,9 @@ static PyModuleDef PyXmlSec_TemplateModule =
     NULL,                     /* m_clear */
     NULL,                     /* m_free */
 };
-#endif  // PY3K
 
 int PyXmlSec_TemplateModule_Init(PyObject* package) {
-#ifdef PY3K
     PyObject* template = PyModule_Create(&PyXmlSec_TemplateModule);
-#else
-    PyObject* template = Py_InitModule3(STRINGIFY(MODULE_NAME) ".template", PyXmlSec_TemplateMethods, PYXMLSEC_TEMPLATES_DOC);
-    Py_XINCREF(template);
-#endif
 
     if (!template) goto ON_FAIL;
     PYXMLSEC_DEBUGF("%p", template);

--- a/src/tree.c
+++ b/src/tree.c
@@ -230,7 +230,6 @@ static PyMethodDef PyXmlSec_TreeMethods[] = {
     {NULL, NULL} /* sentinel */
 };
 
-#ifdef PY3K
 static PyModuleDef PyXmlSec_TreeModule =
 {
     PyModuleDef_HEAD_INIT,
@@ -243,16 +242,10 @@ static PyModuleDef PyXmlSec_TreeModule =
     NULL,                     /* m_clear */
     NULL,                     /* m_free */
 };
-#endif  // PY3K
 
 
 int PyXmlSec_TreeModule_Init(PyObject* package) {
-#ifdef PY3K
     PyObject* tree = PyModule_Create(&PyXmlSec_TreeModule);
-#else
-    PyObject* tree = Py_InitModule3(STRINGIFY(MODULE_NAME) ".tree", PyXmlSec_TreeMethods, PYXMLSEC_TREE_DOC);
-    Py_XINCREF(tree);
-#endif
 
     if (!tree) goto ON_FAIL;
 

--- a/src/tree.c
+++ b/src/tree.c
@@ -182,7 +182,7 @@ static PyObject* PyXmlSec_TreeAddIds(PyObject* self, PyObject *args, PyObject *k
         tmp = PyObject_GetItem(ids, key);
         Py_DECREF(key);
         if (tmp == NULL) goto ON_FAIL;
-        list[i] = XSTR(PyString_AsString(tmp));
+        list[i] = XSTR(PyUnicode_AsUTF8(tmp));
         Py_DECREF(tmp);
         if (list[i] == NULL) goto ON_FAIL;
     }

--- a/src/utils.c
+++ b/src/utils.c
@@ -32,7 +32,7 @@ PyObject* PyXmlSec_GetFilePathOrContent(PyObject* file, int* is_content) {
 }
 
 int PyXmlSec_SetStringAttr(PyObject* obj, const char* name, const char* value) {
-    PyObject* tmp = PyString_FromString(value);
+    PyObject* tmp = PyUnicode_FromString(value);
     int r;
 
     if (tmp == NULL) {

--- a/src/utils.c
+++ b/src/utils.c
@@ -25,7 +25,7 @@ PyObject* PyXmlSec_GetFilePathOrContent(PyObject* file, int* is_content) {
         return data;
     }
     *is_content = 0;
-    if (!PyString_FSConverter(file, &tmp)) {
+    if (!PyUnicode_FSConverter(file, &tmp)) {
         return NULL;
     }
     return tmp;


### PR DESCRIPTION
With Python 2 support dropped in 1.3.10, the distinction between Python 2 and 3 cases is not necessary anymore. This PR drops the Python 2 code bits.