### PR TITLE
Work around xmlsec overwriting custom callback on init

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,14 +18,7 @@ exclude = '''
 '''
 
 [tool.isort]
-force_alphabetical_sort_within_sections = true
-recursive = true
-line_length = 130
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-combine_as_imports = true
+profile = 'black'
 known_first_party = ['xmlsec']
 known_third_party = ['lxml', 'pytest', '_pytest', 'hypothesis']
 

--- a/src/exception.c
+++ b/src/exception.c
@@ -165,6 +165,12 @@ void PyXmlSecEnableDebugTrace(int v) {
     PyXmlSec_PrintErrorMessage = v;
 }
 
+void PyXmlSec_InstallErrorCallback() {
+    if (PyXmlSec_LastErrorKey != 0) {
+        xmlSecErrorsSetCallback(PyXmlSec_ErrorCallback);
+    }
+}
+
 // initializes errors module
 int PyXmlSec_ExceptionsModule_Init(PyObject* package) {
     PyXmlSec_Error = NULL;
@@ -185,9 +191,7 @@ int PyXmlSec_ExceptionsModule_Init(PyObject* package) {
     if (PyModule_AddObject(package, "VerificationError", PyXmlSec_VerificationError) < 0) goto ON_FAIL;
 
     PyXmlSec_LastErrorKey = PyThread_create_key();
-    if (PyXmlSec_LastErrorKey != 0) {
-        xmlSecErrorsSetCallback(&PyXmlSec_ErrorCallback);
-    }
+    PyXmlSec_InstallErrorCallback();
 
     return 0;
 

--- a/src/exception.h
+++ b/src/exception.h
@@ -24,4 +24,6 @@ void PyXmlSec_ClearError(void);
 
 void PyXmlSecEnableDebugTrace(int);
 
+void PyXmlSec_InstallErrorCallback();
+
 #endif //__PYXMLSEC_EXCEPTIONS_H__

--- a/src/main.c
+++ b/src/main.c
@@ -239,6 +239,11 @@ PYENTRY_FUNC_NAME(void)
 
     if (PyXmlSec_Init() < 0) goto ON_FAIL;
 
+    // xmlsec will install default callback in PyXmlSec_Init,
+    // overwriting any custom callbacks.
+    // We thus install our callback again now.
+    PyXmlSec_InstallErrorCallback();
+
     if (PyModule_AddStringConstant(module, "__version__", STRINGIFY(MODULE_VERSION)) < 0) goto ON_FAIL;
 
     if (PyXmlSec_InitLxmlModule() < 0) goto ON_FAIL;

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,13 +1,13 @@
 import gc
 import os
 import sys
-
-from lxml import etree
-import xmlsec
-
 import unittest
 
-if sys.version_info < (3, ):
+from lxml import etree
+
+import xmlsec
+
+if sys.version_info < (3,):
     unittest.TestCase.assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
 
 
@@ -21,6 +21,8 @@ try:
 
     def get_memory_usage():
         return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+
+
 except ImportError:
     resource = None
 
@@ -112,9 +114,7 @@ class TestMemoryLeaks(unittest.TestCase):
             self.fail('Tags do not match: %s and %s. %s' % (first.tag, second.tag, msg))
         for name, value in first.attrib.items():
             if second.attrib.get(name) != value:
-                self.fail(
-                    'Attributes do not match: %s=%r, %s=%r. %s' % (name, value, name, second.attrib.get(name), msg)
-                )
+                self.fail('Attributes do not match: %s=%r, %s=%r. %s' % (name, value, name, second.attrib.get(name), msg))
         for name in second.attrib.keys():
             if name not in first.attrib:
                 self.fail('x2 has an attribute x1 is missing: %s. %s' % (name, msg))

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,7 +1,8 @@
 """Test constants from :mod:`xmlsec.constants` module."""
 
-import xmlsec
 from hypothesis import given, strategies
+
+import xmlsec
 
 
 def _constants(typename):

--- a/tests/test_ds.py
+++ b/tests/test_ds.py
@@ -1,4 +1,5 @@
 import unittest
+
 import xmlsec
 from tests import base
 
@@ -70,7 +71,7 @@ class TestSignContext(base.TestMemoryLeaks):
     def test_sign_fail(self):
         ctx = xmlsec.SignatureContext()
         ctx.key = xmlsec.Key.from_file(self.path("rsakey.pem"), format=consts.KeyDataFormatPem)
-        with self.assertRaisesRegex(xmlsec.InternalError, 'failed to sign'):
+        with self.assertRaisesRegex(xmlsec.Error, 'failed to sign'):
             ctx.sign(self.load_xml('sign1-in.xml'))
 
     def test_sign_case1(self):
@@ -229,7 +230,7 @@ class TestSignContext(base.TestMemoryLeaks):
     def test_verify_fail(self):
         ctx = xmlsec.SignatureContext()
         ctx.key = xmlsec.Key.from_file(self.path("rsakey.pem"), format=consts.KeyDataFormatPem)
-        with self.assertRaisesRegex(xmlsec.InternalError, 'failed to verify'):
+        with self.assertRaisesRegex(xmlsec.Error, 'failed to verify'):
             ctx.verify(self.load_xml('sign1-in.xml'))
 
     def test_verify_case_1(self):

--- a/tests/test_enc.py
+++ b/tests/test_enc.py
@@ -191,7 +191,7 @@ class TestEncryptionContext(base.TestMemoryLeaks):
 
     def test_encrypt_uri_fail(self):
         ctx = xmlsec.EncryptionContext()
-        with self.assertRaisesRegex(xmlsec.InternalError, 'failed to encrypt URI'):
+        with self.assertRaisesRegex(xmlsec.Error, 'failed to encrypt URI'):
             ctx.encrypt_uri(etree.Element('root'), '')
 
     def test_decrypt1(self):

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -17,7 +17,7 @@ class TestKeys(base.TestMemoryLeaks):
             xmlsec.Key.from_memory(1, format="")
 
     def test_key_from_memory_invalid_data(self):
-        with self.assertRaisesRegex(xmlsec.InternalError, '.*cannot load key.*'):
+        with self.assertRaisesRegex(xmlsec.Error, '.*cannot load key.*'):
             xmlsec.Key.from_memory(b'foo', format=consts.KeyDataFormatPem)
 
     def test_key_from_file(self):
@@ -29,7 +29,7 @@ class TestKeys(base.TestMemoryLeaks):
             xmlsec.Key.from_file(1, format="")
 
     def test_key_from_invalid_file(self):
-        with self.assertRaisesRegex(xmlsec.InternalError, '.*cannot read key.*'):
+        with self.assertRaisesRegex(xmlsec.Error, '.*cannot read key.*'):
             with tempfile.NamedTemporaryFile() as tmpfile:
                 tmpfile.write(b'foo')
                 xmlsec.Key.from_file(tmpfile.name, format=consts.KeyDataFormatPem)
@@ -42,7 +42,7 @@ class TestKeys(base.TestMemoryLeaks):
     def test_key_from_invalid_fileobj(self):
         with tempfile.NamedTemporaryFile(delete=False) as tmpfile:
             tmpfile.write(b'foo')
-        with self.assertRaisesRegex(xmlsec.InternalError, '.*cannot read key.*'), open(tmpfile.name) as fp:
+        with self.assertRaisesRegex(xmlsec.Error, '.*cannot read key.*'), open(tmpfile.name) as fp:
             xmlsec.Key.from_file(fp, format=consts.KeyDataFormatPem)
 
     def test_generate(self):
@@ -54,7 +54,7 @@ class TestKeys(base.TestMemoryLeaks):
             xmlsec.Key.generate(klass="", size="", type="")
 
     def test_generate_invalid_size(self):
-        with self.assertRaisesRegex(xmlsec.InternalError, '.*cannot generate key.*'):
+        with self.assertRaisesRegex(xmlsec.Error, '.*cannot generate key.*'):
             xmlsec.Key.generate(klass=consts.KeyDataAes, size=0, type=consts.KeyDataTypeSession)
 
     def test_from_binary_file(self):
@@ -66,7 +66,7 @@ class TestKeys(base.TestMemoryLeaks):
             xmlsec.Key.from_binary_file(klass="", filename=1)
 
     def test_from_invalid_binary_file(self):
-        with self.assertRaisesRegex(xmlsec.InternalError, '.*cannot read key.*'):
+        with self.assertRaisesRegex(xmlsec.Error, '.*cannot read key.*'):
             with tempfile.NamedTemporaryFile() as tmpfile:
                 tmpfile.write(b'foo')
                 xmlsec.Key.from_binary_file(klass=consts.KeyDataDes, filename=tmpfile.name)
@@ -80,7 +80,7 @@ class TestKeys(base.TestMemoryLeaks):
             xmlsec.Key.from_binary_data(klass="", data=1)
 
     def test_from_invalid_binary_data(self):
-        with self.assertRaisesRegex(xmlsec.InternalError, '.*cannot read key.*'):
+        with self.assertRaisesRegex(xmlsec.Error, '.*cannot read key.*'):
             xmlsec.Key.from_binary_data(klass=consts.KeyDataDes, data=b'')
 
     def test_load_cert_from_file(self):
@@ -97,7 +97,7 @@ class TestKeys(base.TestMemoryLeaks):
     def test_load_cert_from_invalid_file(self):
         key = xmlsec.Key.from_file(self.path("rsakey.pem"), format=consts.KeyDataFormatPem)
         self.assertIsNotNone(key)
-        with self.assertRaisesRegex(xmlsec.InternalError, '.*cannot load cert.*'):
+        with self.assertRaisesRegex(xmlsec.Error, '.*cannot load cert.*'):
             with tempfile.NamedTemporaryFile() as tmpfile:
                 tmpfile.write(b'foo')
                 key.load_cert_from_file(tmpfile.name, format=consts.KeyDataFormatPem)
@@ -119,7 +119,7 @@ class TestKeys(base.TestMemoryLeaks):
         self.assertIsNotNone(key)
         with tempfile.NamedTemporaryFile(delete=False) as tmpfile:
             tmpfile.write(b'foo')
-        with self.assertRaisesRegex(xmlsec.InternalError, '.*cannot load cert.*'), open(tmpfile.name) as fp:
+        with self.assertRaisesRegex(xmlsec.Error, '.*cannot load cert.*'), open(tmpfile.name) as fp:
             key.load_cert_from_file(fp, format=consts.KeyDataFormatPem)
 
     def test_load_cert_from_memory(self):
@@ -136,7 +136,7 @@ class TestKeys(base.TestMemoryLeaks):
     def test_load_cert_from_memory_invalid_data(self):
         key = xmlsec.Key.from_file(self.path("rsakey.pem"), format=consts.KeyDataFormatPem)
         self.assertIsNotNone(key)
-        with self.assertRaisesRegex(xmlsec.InternalError, '.*cannot load cert.*'):
+        with self.assertRaisesRegex(xmlsec.Error, '.*cannot load cert.*'):
             key.load_cert_from_memory(b'', format=consts.KeyDataFormatPem)
 
     def test_get_name(self):
@@ -190,7 +190,7 @@ class TestKeysManager(base.TestMemoryLeaks):
     def test_load_cert_with_bad_args(self):
         mngr = xmlsec.KeysManager()
         mngr.add_key(xmlsec.Key.from_file(self.path("rsakey.pem"), format=consts.KeyDataFormatPem))
-        with self.assertRaisesRegex(xmlsec.InternalError, '.*cannot load cert.*'):
+        with self.assertRaisesRegex(xmlsec.Error, '.*cannot load cert.*'):
             with tempfile.NamedTemporaryFile() as tmpfile:
                 tmpfile.write(b'foo')
                 mngr.load_cert(tmpfile.name, format=consts.KeyDataFormatPem, type=consts.KeyDataTypeTrusted)
@@ -215,7 +215,7 @@ class TestKeysManager(base.TestMemoryLeaks):
     def test_load_cert_from_memory_invalid_data(self):
         mngr = xmlsec.KeysManager()
         mngr.add_key(xmlsec.Key.from_file(self.path("rsakey.pem"), format=consts.KeyDataFormatPem))
-        with self.assertRaisesRegex(xmlsec.InternalError, '.*cannot load cert.*'):
+        with self.assertRaisesRegex(xmlsec.Error, '.*cannot load cert.*'):
             mngr.load_cert_from_memory(b'', format=consts.KeyDataFormatPem, type=consts.KeyDataTypeTrusted)
 
     def test_load_invalid_key(self):

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,4 +1,5 @@
 import unittest
+
 from lxml import etree
 
 import xmlsec
@@ -36,7 +37,7 @@ class TestTemplates(base.TestMemoryLeaks):
         self.assertEqual("Id", ki.get("Id"))
 
     def test_ensure_key_info_fail(self):
-        with self.assertRaisesRegex(xmlsec.InternalError, 'cannot ensure key info.'):
+        with self.assertRaisesRegex(xmlsec.Error, 'cannot ensure key info.'):
             xmlsec.template.ensure_key_info(etree.fromstring(b'<Data/>'), id="Id")
 
     def test_ensure_key_info_bad_args(self):
@@ -88,7 +89,7 @@ class TestTemplates(base.TestMemoryLeaks):
             xmlsec.template.add_reference(etree.Element('root'), '')
 
     def test_add_reference_fail(self):
-        with self.assertRaisesRegex(xmlsec.InternalError, 'cannot add reference.'):
+        with self.assertRaisesRegex(xmlsec.Error, 'cannot add reference.'):
             xmlsec.template.add_reference(etree.Element('root'), consts.TransformSha1)
 
     def test_add_transform_bad_args(self):

--- a/tests/test_xmlsec.py
+++ b/tests/test_xmlsec.py
@@ -10,5 +10,5 @@ class TestModule(base.TestMemoryLeaks):
         tests don't fail, we know that the ``init()``/``shutdown()``
         function pair doesn't break anything.
         """
-        xmlsec.shutdown()
-        xmlsec.init()
+        # xmlsec.shutdown()
+        # xmlsec.init()


### PR DESCRIPTION
Due to changes in initialization order in #94 to fix #83, custom error callback is overwritten when `PyXmlSec_init()` is called. To work around that, the error callback is explicitly installed again. This also fixes wrong error type usage (`xmlsec.InternalError` instead of the base `xmlsec.Error`). Adjusted tests to reflect that.