### PR TITLE
Use Python 3.8 to build docs on RTD as 3.9 is not supported yet

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,7 +4,7 @@ sphinx:
   configuration: doc/source/conf.py
 
 python:
-  version: 3.9
+  version: 3.8
   install:
     - method: pip
       path: .


### PR DESCRIPTION
Signed-off-by: oleg.hoefling <oleg.hoefling@gmail.com>