### PR TITLE
Reinstall custom error callback after xmlSecCryptoInit()

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -87,6 +87,11 @@ static int PyXmlSec_Init(void) {
         PyXmlSec_Free(_PYXMLSEC_FREE_ALL);
         return -1;
     }
+    // xmlsec will install default callback in xmlSecCryptoInit,
+    // overwriting any custom callbacks.
+    // We thus reinstall our callback now.
+    PyXmlSec_InstallErrorCallback();
+
     free_mode = _PYXMLSEC_FREE_ALL;
     return 0;
 }
@@ -238,11 +243,6 @@ PYENTRY_FUNC_NAME(void)
     if (PyXmlSec_ExceptionsModule_Init(module) < 0) goto ON_FAIL;
 
     if (PyXmlSec_Init() < 0) goto ON_FAIL;
-
-    // xmlsec will install default callback in PyXmlSec_Init,
-    // overwriting any custom callbacks.
-    // We thus install our callback again now.
-    PyXmlSec_InstallErrorCallback();
 
     if (PyModule_AddStringConstant(module, "__version__", STRINGIFY(MODULE_VERSION)) < 0) goto ON_FAIL;
 

--- a/tests/test_xmlsec.py
+++ b/tests/test_xmlsec.py
@@ -10,5 +10,5 @@ class TestModule(base.TestMemoryLeaks):
         tests don't fail, we know that the ``init()``/``shutdown()``
         function pair doesn't break anything.
         """
-        # xmlsec.shutdown()
-        # xmlsec.init()
+        xmlsec.shutdown()
+        xmlsec.init()


### PR DESCRIPTION
A better approach than in #175 is to reinstall error callback after `xmlSecCryptoInit()` invocation. This will also increase test coverage a bit more.