### PR TITLE
fix warning related to use of dash seperated values

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,9 @@
 [metadata]
-description-file = README.rst
+description_file = README.rst
 
 [bdist_rpm]
 release = 1
-build-requires = pkg-config xmlsec1-devel libxml2-devel xmlsec1-openssl-devel
+build_requires = pkg-config xmlsec1-devel libxml2-devel xmlsec1-openssl-devel
 group = Development/Libraries
 requires = xmlsec1 xmlsec1-openssl
 
@@ -13,7 +13,7 @@ build-dir  = doc/build
 all_files  = 1
 
 [upload_docs]
-upload-dir = doc/build/html
+upload_dir = doc/build/html
 
 [flake8]
 max-line-length = 130


### PR DESCRIPTION
Fixes https://github.com/mehcode/python-xmlsec/issues/182
Making changes in setup.cfg to fix the warning related to use of
dash-seperated values