### PR TITLE
First cut of registering Python callbacks for xmlsec

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -194,9 +194,9 @@ static int PyXmlSec_MatchCB(const char* filename) {
             PyGILState_Release(state);
             return 1;
         }
+        Py_XDECREF(result);
         cur_cb_list_item = cur_cb_list_item->next;
     }
-    // FIXME: why does having this decref of args cause a segfault?!
     Py_DECREF(args);
     PyGILState_Release(state);
     return 0;
@@ -228,10 +228,10 @@ static int PyXmlSec_ReadCB(void* context, char* buffer, int len) {
     int result;
     if (py_bytes_read && PyLong_Check(py_bytes_read)) {
         result = (int)PyLong_AsLong(py_bytes_read);
-        Py_DECREF(py_bytes_read);
     } else {
         result = EOF;
     }
+    Py_XDECREF(py_bytes_read);
 
     PyGILState_Release(state);
     return result;
@@ -331,18 +331,22 @@ static PyObject* PyXmlSec_PyIORegisterCallbacks(PyObject *self, PyObject *args, 
     }
     if (!PyCallable_Check(cb_list_item->match_cb)) {
         PyErr_SetString(PyExc_TypeError, "input_match_callback must be a callable");
+        free(cb_list_item);
         return NULL;
     }
     if (!PyCallable_Check(cb_list_item->open_cb)) {
         PyErr_SetString(PyExc_TypeError, "input_open_callback must be a callable");
+        free(cb_list_item);
         return NULL;
     }
     if (!PyCallable_Check(cb_list_item->read_cb)) {
         PyErr_SetString(PyExc_TypeError, "input_read_callback must be a callable");
+        free(cb_list_item);
         return NULL;
     }
     if (!PyCallable_Check(cb_list_item->close_cb)) {
         PyErr_SetString(PyExc_TypeError, "input_close_callback must be a callable");
+        free(cb_list_item);
         return NULL;
     }
     Py_INCREF(cb_list_item->match_cb);

--- a/src/main.c
+++ b/src/main.c
@@ -15,6 +15,7 @@
 #include <xmlsec/crypto.h>
 #include <xmlsec/errors.h>
 #include <xmlsec/base64.h>
+#include <xmlsec/io.h>
 
 #define _PYXMLSEC_FREE_NONE 0
 #define _PYXMLSEC_FREE_XMLSEC 1
@@ -133,6 +134,229 @@ static PyObject* PyXmlSec_PyEnableDebugOutput(PyObject *self, PyObject* args, Py
     Py_RETURN_NONE;
 }
 
+// NB: This whole thing assumes that the `xmlsec` callbacks are not re-entrant
+// (i.e. that xmlsec won't come across a link in the reference it's processing
+// and try to open that with these callbacks too).
+typedef struct CbList {
+  PyObject* match_cb;
+  PyObject* open_cb;
+  PyObject* read_cb;
+  PyObject* close_cb;
+  struct CbList* next;
+} CbList;
+
+static CbList* registered_callbacks = NULL;
+static CbList* rcb_tail = NULL;
+
+static void RCBListAppend(CbList* cb_list_item) {
+    if (registered_callbacks == NULL) {
+      registered_callbacks = cb_list_item;
+    } else {
+      rcb_tail->next = cb_list_item;
+    }
+    rcb_tail = cb_list_item;
+}
+
+static void RCBListClear() {
+    CbList* cb_list_item = registered_callbacks;
+    while (cb_list_item) {
+        Py_XDECREF(cb_list_item->match_cb);
+        Py_XDECREF(cb_list_item->open_cb);
+        Py_XDECREF(cb_list_item->read_cb);
+        Py_XDECREF(cb_list_item->close_cb);
+        CbList* next = cb_list_item->next;
+        free(cb_list_item);
+        cb_list_item = next;
+    }
+    registered_callbacks = NULL;
+    rcb_tail = NULL;
+}
+
+// The currently executing set of Python callbacks:
+static CbList* cur_cb_list_item = NULL;
+
+static int PyXmlSec_MatchCB(const char* filename) {
+    if (!cur_cb_list_item) {
+      cur_cb_list_item = registered_callbacks;
+    }
+    while (cur_cb_list_item && !cur_cb_list_item->match_cb) {
+        // Spool past any default callback placeholders executed since we were
+        // last called back:
+        cur_cb_list_item = cur_cb_list_item->next;
+    }
+    PyGILState_STATE state = PyGILState_Ensure();
+    PyObject* args = Py_BuildValue("(y)", filename);
+    while (cur_cb_list_item && cur_cb_list_item->match_cb) {
+        PyObject* result = PyObject_CallObject(cur_cb_list_item->match_cb, args);
+        if (result && PyObject_IsTrue(result)) {
+            Py_DECREF(result);
+            Py_DECREF(args);
+            PyGILState_Release(state);
+            return 1;
+        }
+        cur_cb_list_item = cur_cb_list_item->next;
+    }
+    // FIXME: why does having this decref of args cause a segfault?!
+    Py_DECREF(args);
+    PyGILState_Release(state);
+    return 0;
+}
+
+static void* PyXmlSec_OpenCB(const char* filename) {
+    PyGILState_STATE state = PyGILState_Ensure();
+
+    // NB: Assumes the match callback left the current callback list item in the
+    // right place:
+    PyObject* args = Py_BuildValue("(y)", filename);
+    PyObject* result = PyObject_CallObject(cur_cb_list_item->open_cb, args);
+    Py_DECREF(args);
+
+    PyGILState_Release(state);
+    return result;
+}
+
+static int PyXmlSec_ReadCB(void* context, char* buffer, int len) {
+    PyGILState_STATE state = PyGILState_Ensure();
+
+    // NB: Assumes the match callback left the current callback list item in the
+    // right place:
+    PyObject* py_buffer = PyMemoryView_FromMemory(buffer, (Py_ssize_t) len, PyBUF_WRITE);
+    PyObject* args = Py_BuildValue("(OO)", context, py_buffer);
+    PyObject* py_bytes_read = PyObject_CallObject(cur_cb_list_item->read_cb, args);
+    Py_DECREF(args);
+    Py_DECREF(py_buffer);
+    int result;
+    if (py_bytes_read && PyLong_Check(py_bytes_read)) {
+        result = (int)PyLong_AsLong(py_bytes_read);
+        Py_DECREF(py_bytes_read);
+    } else {
+        result = EOF;
+    }
+
+    PyGILState_Release(state);
+    return result;
+}
+
+static int PyXmlSec_CloseCB(void* context) {
+    PyGILState_STATE state = PyGILState_Ensure();
+
+    PyObject* args = Py_BuildValue("(O)", context);
+    PyObject* result = PyObject_CallObject(cur_cb_list_item->close_cb, args);
+    Py_DECREF(args);
+    Py_DECREF(context);
+    Py_DECREF(result);
+
+    PyGILState_Release(state);
+    // We reset `cur_cb_list_item` because we've finished processing the set of
+    // callbacks that was matched
+    cur_cb_list_item = NULL;
+    return 0;
+}
+
+static char PyXmlSec_PyIOCleanupCallbacks__doc__[] = \
+    "Unregister globally all sets of IO callbacks from xmlsec.";
+static PyObject* PyXmlSec_PyIOCleanupCallbacks(PyObject *self) {
+    xmlSecIOCleanupCallbacks();
+    // We always have callbacks registered to delegate to any Python callbacks
+    // we have registered within these bindings:
+    if (xmlSecIORegisterCallbacks(
+            PyXmlSec_MatchCB, PyXmlSec_OpenCB, PyXmlSec_ReadCB,
+            PyXmlSec_CloseCB) < 0) {
+        return NULL;
+    };
+    RCBListClear();
+    Py_RETURN_NONE;
+}
+
+static char PyXmlSec_PyIORegisterDefaultCallbacks__doc__[] = \
+    "Register globally xmlsec's own default set of IO callbacks.";
+static PyObject* PyXmlSec_PyIORegisterDefaultCallbacks(PyObject *self) {
+    if (xmlSecIORegisterDefaultCallbacks() < 0) {
+        return NULL;
+    }
+    // We place a nulled item on the callback list to represent whenever the
+    // default callbacks are going to be invoked:
+    CbList* cb_list_item = malloc(sizeof(CbList));
+    if (cb_list_item == NULL) {
+      return NULL;
+    }
+    cb_list_item->match_cb = NULL;
+    cb_list_item->open_cb = NULL;
+    cb_list_item->read_cb = NULL;
+    cb_list_item->close_cb = NULL;
+    cb_list_item->next = NULL;
+    RCBListAppend(cb_list_item);
+    // We need to make sure we can continue trying to match futher Python
+    // callbacks if the default callback doesn't match:
+    if (xmlSecIORegisterCallbacks(
+            PyXmlSec_MatchCB, PyXmlSec_OpenCB, PyXmlSec_ReadCB,
+            PyXmlSec_CloseCB) < 0) {
+        return NULL;
+    };
+    Py_RETURN_NONE;
+}
+
+static char PyXmlSec_PyIORegisterCallbacks__doc__[] = \
+    "Register globally a custom set of IO callbacks with xmlsec.\n\n"
+    ":param callable input_match_callback: A callable that takes a filename `bytestring` and "
+    "returns a boolean as to whether the other callbacks in this set can handle that name.\n"
+    ":param callable input_open_callback: A callable that takes a filename and returns some "
+    "context object (e.g. a file object) that the remaining callables in this set will be passed "
+    "during handling.\n"
+    // FIXME: How do we handle failures in ^^ (e.g. can't find the file)?
+    ":param callable input_read_callback: A callable that that takes the context object from the "
+    "open callback and a buffer, and should fill the buffer with data (e.g. BytesIO.readinto()). "
+    "xmlsec will call this function several times until there is no more data returned.\n"
+    ":param callable input_close_callback: A callable that takes the context object from the "
+    "open callback and can do any resource cleanup necessary.\n"
+    ;
+static PyObject* PyXmlSec_PyIORegisterCallbacks(PyObject *self, PyObject *args, PyObject *kwargs) {
+    static char *kwlist[] = {
+        "input_match_callback",
+        "input_open_callback",
+        "input_read_callback",
+        "input_close_callback",
+        NULL
+    };
+    CbList* cb_list_item = malloc(sizeof(CbList));
+    if (cb_list_item == NULL) {
+      return NULL;
+    }
+    if (!PyArg_ParseTupleAndKeywords(
+            args, kwargs, "OOOO:register_callbacks", kwlist,
+            &cb_list_item->match_cb, &cb_list_item->open_cb, &cb_list_item->read_cb,
+            &cb_list_item->close_cb)) {
+        free(cb_list_item);
+        return NULL;
+    }
+    if (!PyCallable_Check(cb_list_item->match_cb)) {
+        PyErr_SetString(PyExc_TypeError, "input_match_callback must be a callable");
+        return NULL;
+    }
+    if (!PyCallable_Check(cb_list_item->open_cb)) {
+        PyErr_SetString(PyExc_TypeError, "input_open_callback must be a callable");
+        return NULL;
+    }
+    if (!PyCallable_Check(cb_list_item->read_cb)) {
+        PyErr_SetString(PyExc_TypeError, "input_read_callback must be a callable");
+        return NULL;
+    }
+    if (!PyCallable_Check(cb_list_item->close_cb)) {
+        PyErr_SetString(PyExc_TypeError, "input_close_callback must be a callable");
+        return NULL;
+    }
+    Py_INCREF(cb_list_item->match_cb);
+    Py_INCREF(cb_list_item->open_cb);
+    Py_INCREF(cb_list_item->read_cb);
+    Py_INCREF(cb_list_item->close_cb);
+    cb_list_item->next = NULL;
+    RCBListAppend(cb_list_item);
+    // NB: We don't need to register the callbacks with `xmlsec` here, because
+    // we've already registered our helper functions that will trawl through our
+    // list of callbacks.
+    Py_RETURN_NONE;
+}
+
 static char PyXmlSec_PyBase64DefaultLineSize__doc__[] = \
     "base64_default_line_size(size = None)\n"
     "Configures the default maximum columns size for base64 encoding.\n\n"
@@ -180,6 +404,24 @@ static PyMethodDef PyXmlSec_MainMethods[] = {
         (PyCFunction)PyXmlSec_PyEnableDebugOutput,
         METH_VARARGS|METH_KEYWORDS,
         PyXmlSec_PyEnableDebugOutput__doc__
+    },
+    {
+        "cleanup_callbacks",
+        (PyCFunction)PyXmlSec_PyIOCleanupCallbacks,
+        METH_NOARGS,
+        PyXmlSec_PyIOCleanupCallbacks__doc__
+    },
+    {
+        "register_default_callbacks",
+        (PyCFunction)PyXmlSec_PyIORegisterDefaultCallbacks,
+        METH_NOARGS,
+        PyXmlSec_PyIORegisterDefaultCallbacks__doc__
+    },
+    {
+        "register_callbacks",
+        (PyCFunction)PyXmlSec_PyIORegisterCallbacks,
+        METH_VARARGS|METH_KEYWORDS,
+        PyXmlSec_PyIORegisterCallbacks__doc__
     },
     {
         "base64_default_line_size",

--- a/src/xmlsec/__init__.pyi
+++ b/src/xmlsec/__init__.pyi
@@ -1,5 +1,7 @@
 import sys
-from typing import AnyStr, IO, Iterable, Optional, Type, TypeVar, Union, overload
+from typing import (
+    Any, AnyStr, Callable, IO, Iterable, Optional, Type, TypeVar, Union,
+    overload)
 
 from lxml.etree import _Element
 
@@ -24,6 +26,14 @@ _K = TypeVar('_K', bound=Key)
 def enable_debug_trace(enabled: bool = ...) -> None: ...
 def init() -> None: ...
 def shutdown() -> None: ...
+def cleanup_callbacks() -> None: ...
+def register_default_callbacks() -> None: ...
+def register_callbacks(
+        input_match_callback: Callable[[bytes], bool],
+        input_open_callback: Callable[[bytes], Any],
+        input_read_callback: Callable[[Any, memoryview], int],
+        input_close_callback: Callable[[Any], None],
+) -> None: ...
 @overload
 def base64_default_line_size() -> int: ...
 @overload

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -60,8 +60,8 @@ class TestCallbacks(base.TestMemoryLeaks):
         return sign
 
     def _expect_sign_failure(self):
-        exc_info = pytest.raises(xmlsec.Error, self._sign_doc)
-        self.assertEqual(exc_info.value.args, (1, 'failed to sign'))
+        with self.assertRaisesRegex(xmlsec.Error, 'failed to sign'):
+            self._sign_doc()
 
     def _register_mismatch_callbacks(self, match_cb=lambda filename: False):
         xmlsec.register_callbacks(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,3 @@
-from lxml import etree
 import xmlsec
 from xmlsec import constants as consts
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,9 +1,9 @@
+from lxml import etree
 import xmlsec
 from xmlsec import constants as consts
 
 from io import BytesIO
 
-import pytest
 from tests import base
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,10 @@
 import xmlsec
+from xmlsec import constants as consts
+
+from io import BytesIO
+
+from hypothesis import given, strategies
+import pytest
 from tests import base
 
 
@@ -30,3 +36,131 @@ class TestBase64LineSize(base.TestMemoryLeaks):
         with self.assertRaises(ValueError):
             xmlsec.base64_default_line_size(-1)
         self.assertEqual(xmlsec.base64_default_line_size(), size)
+
+
+class TestCallbacks(base.TestMemoryLeaks):
+    def setUp(self):
+        super().setUp()
+        xmlsec.cleanup_callbacks()
+
+    @given(funcs=strategies.lists(
+        strategies.sampled_from([
+            lambda: None
+            # xmlsec.cleanup_callbacks,
+            # xmlsec.register_default_callbacks,
+        ])
+    ))
+    def test_arbitrary_cleaning_and_default_callback_registration(self, funcs):
+        # FIXME: This test seems to detelct unreferenced objects and memory
+        # leaks even if it never does anything!
+        pass
+        # for f in funcs:
+        #     f()
+
+    def _sign_doc(self):
+        root = self.load_xml("doc.xml")
+        sign = xmlsec.template.create(
+            root,
+            c14n_method=consts.TransformExclC14N,
+            sign_method=consts.TransformRsaSha1
+        )
+        xmlsec.template.add_reference(
+            sign, consts.TransformSha1, uri="cid:123456")
+
+        ctx = xmlsec.SignatureContext()
+        ctx.key = xmlsec.Key.from_file(
+            self.path("rsakey.pem"), format=consts.KeyDataFormatPem
+        )
+        ctx.sign(sign)
+        return sign
+
+    def _expect_sign_failure(self):
+        exc_info = pytest.raises(xmlsec.Error, self._sign_doc)
+        self.assertEqual(exc_info.value.args, (1, 'failed to sign'))
+
+    def _register_mismatch_callbacks(self, match_cb=lambda filename: False):
+        xmlsec.register_callbacks(
+            match_cb,
+            lambda filename: None,
+            lambda none, buf: 0,
+            lambda none: None,
+        )
+
+    def _register_match_callbacks(self):
+        xmlsec.register_callbacks(
+            lambda filename: filename == b'cid:123456',
+            lambda filename: BytesIO(b'<html><head/><body/></html>'),
+            lambda bio, buf: bio.readinto(buf),
+            lambda bio: bio.close(),
+        )
+
+    def _find(self, elem, *tags):
+        for tag in tags:
+            elem = elem.find(
+                '{{http://www.w3.org/2000/09/xmldsig#}}{}'.format(tag))
+        return elem
+
+    def _verify_external_data_signature(self):
+        signature = self._sign_doc()
+        digest = self._find(
+            signature, 'SignedInfo', 'Reference', 'DigestValue'
+        ).text
+        self.assertEqual(digest, 'VihZwVMGJ48NsNl7ertVHiURXk8=')
+
+    def test_sign_external_data_no_callbacks_fails(self):
+        self._expect_sign_failure()
+
+    def test_sign_external_data_default_callbacks_fails(self):
+        xmlsec.register_default_callbacks()
+        self._expect_sign_failure()
+
+    def test_sign_external_data_no_matching_callbacks_fails(self):
+        self._register_mismatch_callbacks()
+        self._expect_sign_failure()
+
+    def test_sign_data_from_callbacks(self):
+        self._register_match_callbacks()
+        self._verify_external_data_signature()
+
+    @given(
+        num_prior_mismatches=strategies.integers(min_value=1, max_value=50),
+        num_post_mismatches=strategies.integers(min_value=1, max_value=50),
+    )
+    def test_sign_data_not_first_callback(
+            self, num_prior_mismatches, num_post_mismatches
+    ):
+        bad_match_calls = 0
+
+        def match_cb(filename):
+            nonlocal bad_match_calls
+            bad_match_calls += 1
+            False
+
+        for _ in range(num_post_mismatches):
+            self._register_mismatch_callbacks(match_cb)
+
+        self._register_match_callbacks()
+
+        for _ in range(num_prior_mismatches):
+            self._register_mismatch_callbacks()
+
+        self._verify_external_data_signature()
+        self.assertEqual(bad_match_calls, 0)
+
+    def test_failed_sign_because_default_callbacks(self):
+        mismatch_calls = 0
+
+        def mismatch_cb(filename):
+            nonlocal mismatch_calls
+            mismatch_calls += 1
+            False
+
+        # NB: These first two sets of callbacks should never get called,
+        # because the default callbacks always match beforehand:
+        self._register_match_callbacks()
+        self._register_mismatch_callbacks(mismatch_cb)
+        xmlsec.register_default_callbacks()
+        self._register_mismatch_callbacks(mismatch_cb)
+        self._register_mismatch_callbacks(mismatch_cb)
+        self._expect_sign_failure()
+        self.assertEqual(mismatch_calls, 2)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -62,13 +62,16 @@ class TestCallbacks(base.TestMemoryLeaks):
         with self.assertRaisesRegex(xmlsec.Error, 'failed to sign'):
             self._sign_doc()
 
-    def _register_mismatch_callbacks(self, match_cb=lambda filename: False):
-        xmlsec.register_callbacks(
+    def _mismatch_callbacks(self, match_cb=lambda filename: False):
+        return [
             match_cb,
             lambda filename: None,
             lambda none, buf: 0,
             lambda none: None,
-        )
+        ]
+
+    def _register_mismatch_callbacks(self, match_cb=lambda filename: False):
+        xmlsec.register_callbacks(*self._mismatch_callbacks(match_cb))
 
     def _register_match_callbacks(self):
         xmlsec.register_callbacks(
@@ -147,3 +150,9 @@ class TestCallbacks(base.TestMemoryLeaks):
         self._register_mismatch_callbacks(mismatch_cb)
         self._expect_sign_failure()
         self.assertEqual(mismatch_calls, 2)
+
+    def test_register_non_callables(self):
+        for idx in range(4):
+            cbs = self._mismatch_callbacks()
+            cbs[idx] = None
+            self.assertRaises(TypeError, xmlsec.register_callbacks, *cbs)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,7 +3,6 @@ from xmlsec import constants as consts
 
 from io import BytesIO
 
-from hypothesis import given, strategies
 import pytest
 from tests import base
 
@@ -42,20 +41,6 @@ class TestCallbacks(base.TestMemoryLeaks):
     def setUp(self):
         super().setUp()
         xmlsec.cleanup_callbacks()
-
-    @given(funcs=strategies.lists(
-        strategies.sampled_from([
-            lambda: None
-            # xmlsec.cleanup_callbacks,
-            # xmlsec.register_default_callbacks,
-        ])
-    ))
-    def test_arbitrary_cleaning_and_default_callback_registration(self, funcs):
-        # FIXME: This test seems to detelct unreferenced objects and memory
-        # leaks even if it never does anything!
-        pass
-        # for f in funcs:
-        #     f()
 
     def _sign_doc(self):
         root = self.load_xml("doc.xml")
@@ -122,13 +107,7 @@ class TestCallbacks(base.TestMemoryLeaks):
         self._register_match_callbacks()
         self._verify_external_data_signature()
 
-    @given(
-        num_prior_mismatches=strategies.integers(min_value=1, max_value=50),
-        num_post_mismatches=strategies.integers(min_value=1, max_value=50),
-    )
-    def test_sign_data_not_first_callback(
-            self, num_prior_mismatches, num_post_mismatches
-    ):
+    def test_sign_data_not_first_callback(self):
         bad_match_calls = 0
 
         def match_cb(filename):
@@ -136,12 +115,12 @@ class TestCallbacks(base.TestMemoryLeaks):
             bad_match_calls += 1
             False
 
-        for _ in range(num_post_mismatches):
+        for _ in range(2):
             self._register_mismatch_callbacks(match_cb)
 
         self._register_match_callbacks()
 
-        for _ in range(num_prior_mismatches):
+        for _ in range(2):
             self._register_mismatch_callbacks()
 
         self._verify_external_data_signature()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -80,10 +80,15 @@ class TestCallbacks(base.TestMemoryLeaks):
         )
 
     def _find(self, elem, *tags):
-        for tag in tags:
-            elem = elem.find(
-                '{{http://www.w3.org/2000/09/xmldsig#}}{}'.format(tag))
-        return elem
+        try:
+            return elem.xpath(
+                './' + '/'.join('xmldsig:{}'.format(tag) for tag in tags),
+                namespaces={
+                    'xmldsig': 'http://www.w3.org/2000/09/xmldsig#',
+                }
+            )[0]
+        except IndexError as e:
+            raise KeyError(tags) from e
 
     def _verify_external_data_signature(self):
         signature = self._sign_doc()


### PR DESCRIPTION
This is an attempt to address #187 with the giant caveat that I am not a regular C developer and have limited experience with the Python C-API, so I could have committed all sorts of heinous crimes.

This implementation uses a global linked-list structure to hold onto the
Python callbacks and registers a single C wrapper callback with xmlsec to
dispatch xmlsec's calling back to the appropriate Python function. This was
the simplest way I could think to emulate dynamically wrapping the Python
calls in C code, because C doesn't have closures.

A potential downside is that the state is all very global. Perhaps,
however, that's no worse than the very global set of callbacks that xmlsec
holds onto itself, so long as we don't have any strange threading stuff
going on.

In order to accommodate client code potentially interleaving registrations
of the default callbacks in between their own callbacks, the linked list
structure can have nodes with NULL function pointers in it, such that when
iterating through Python callbacks we can suspend our iteration and
delegate back to the defaults at the appropriate point.

As such, we always actually have the Python binding's C callbacks
registered with xmlsec, and every time we get asked to register the default
callbacks, we note a NULL function pointer and then re-register our C
callbacks.