### PR TITLE
Added missing pkg-config dependency.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ Linux (Debian)
 
 .. code-block:: bash
 
-   apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+   apt-get install pkg-config libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
 
 Note: There is no required version of LibXML2 for Ubuntu Precise,


### PR DESCRIPTION
This seems to be required when using python3-slim debian image.

Resolves

```#10 182.5 Building wheels for collected packages: xmlsec
#10 182.5   Building wheel for xmlsec (PEP 517): started
#10 182.9   Building wheel for xmlsec (PEP 517): finished with status 'error'
#10 182.9   ERROR: Command errored out with exit status 1:
#10 182.9    command: /venv/bin/python3.6 /venv/lib/python3.6/site-packages/pip/_vendor/pep517/in_process/_in_process.py build_wheel /tmp/tmpr1_o4zak
#10 182.9        cwd: /tmp/pip-install-amr3abkp/xmlsec_201c200071954684a9d29b2158df27bc
#10 182.9   Complete output (20 lines):
#10 182.9   /tmp/pip-build-env-hr3wr4uf/overlay/lib/python3.6/site-packages/setuptools/dist.py:700: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead
#10 182.9     % (opt, underscore_opt))
#10 182.9   /tmp/pip-build-env-hr3wr4uf/overlay/lib/python3.6/site-packages/setuptools/dist.py:700: UserWarning: Usage of dash-separated 'build-requires' will not be supported in future versions. Please use the underscore name 'build_requires' instead
#10 182.9     % (opt, underscore_opt))
#10 182.9   /tmp/pip-build-env-hr3wr4uf/overlay/lib/python3.6/site-packages/setuptools/dist.py:700: UserWarning: Usage of dash-separated 'upload-dir' will not be supported in future versions. Please use the underscore name 'upload_dir' instead
#10 182.9     % (opt, underscore_opt))
#10 182.9   running bdist_wheel
#10 182.9   running build
#10 182.9   running build_py
#10 182.9   package init file 'src/xmlsec/__init__.py' not found (or not a regular file)
#10 182.9   creating build
#10 182.9   creating build/lib.linux-x86_64-3.6
#10 182.9   creating build/lib.linux-x86_64-3.6/xmlsec
#10 182.9   copying src/xmlsec/py.typed -> build/lib.linux-x86_64-3.6/xmlsec
#10 182.9   copying src/xmlsec/constants.pyi -> build/lib.linux-x86_64-3.6/xmlsec
#10 182.9   copying src/xmlsec/template.pyi -> build/lib.linux-x86_64-3.6/xmlsec
#10 182.9   copying src/xmlsec/__init__.pyi -> build/lib.linux-x86_64-3.6/xmlsec
#10 182.9   copying src/xmlsec/tree.pyi -> build/lib.linux-x86_64-3.6/xmlsec
#10 182.9   running build_ext
#10 182.9   error: Unable to invoke pkg-config.
#10 182.9   ----------------------------------------
#10 182.9   ERROR: Failed building wheel for xmlsec
#10 182.9 ERROR: Could not build wheels for xmlsec which use PEP 517 and cannot be installed directly
#10 182.9 Failed to build xmlsec
```

@hoefling 