### PR TITLE
Switch on modern headers lxml

### DIFF
--- a/src/lxml.c
+++ b/src/lxml.c
@@ -11,7 +11,7 @@
 #include "lxml.h"
 
 #include <etree_defs.h>
-#include <lxml.etree_api.h>
+#include <etree_api.h>
 
 #include <libxml/xmlmemory.h>
 #include <libxml/parser.h>

--- a/src/lxml.h
+++ b/src/lxml.h
@@ -16,7 +16,7 @@
 #include <libxml/valid.h>
 
 #include <lxml-version.h>
-#include <lxml.etree.h>
+#include <etree.h>
 
 typedef struct LxmlElement* PyXmlSec_LxmlElementPtr;
 typedef struct LxmlDocument* PyXmlSec_LxmlDocumentPtr;


### PR DESCRIPTION
Example from lxml documentation - https://lxml.de/capi.html#writing-external-modules-in-c
Also comment from source code - https://github.com/lxml/lxml/blob/master/setupinfo.py#L181
