### PR TITLE
Fix type mismatch in PyXmlSec_ClearReplacedNodes for Python 3.13 compatibility

### DIFF
--- a/src/enc.c
+++ b/src/enc.c
@@ -195,7 +195,7 @@ ON_FAIL:
 
 // release the replaced nodes in a way safe for `lxml`
 static void PyXmlSec_ClearReplacedNodes(xmlSecEncCtxPtr ctx, PyXmlSec_LxmlDocumentPtr doc) {
-    PyXmlSec_LxmlElementPtr* elem;
+    PyXmlSec_LxmlElementPtr elem;
     // release the replaced nodes in a way safe for `lxml`
     xmlNodePtr n = ctx->replacedNodeList;
     xmlNodePtr nn;
@@ -204,7 +204,7 @@ static void PyXmlSec_ClearReplacedNodes(xmlSecEncCtxPtr ctx, PyXmlSec_LxmlDocume
         PYXMLSEC_DEBUGF("clear replaced node %p", n);
         nn = n->next;
         // if n has references, it will not be deleted
-        elem = (PyXmlSec_LxmlElementPtr*)PyXmlSec_elementFactory(doc, n);
+        elem = (PyXmlSec_LxmlElementPtr)PyXmlSec_elementFactory(doc, n);
         if (NULL == elem)
             xmlFreeNode(n);
         else


### PR DESCRIPTION
I’ve encountered a build failure with Python 3.13 caused by a type mismatch in the PyXmlSec_ClearReplacedNodes function. The issue arises because the variable elem is declared as a pointer-to-pointer (PyXmlSec_LxmlElementPtr*) instead of the correct pointer type (PyXmlSec_LxmlElementPtr). This misdeclaration leads to an incorrect argument being passed to Py_DECREF, which Python 3.13 now rejects due to its stricter type checking.

Changes:
	•	Changed the declaration of elem from PyXmlSec_LxmlElementPtr* elem; to PyXmlSec_LxmlElementPtr elem;
	•	Updated the cast accordingly in the call to PyXmlSec_elementFactory

Benefits:
	•	Resolves build errors on Python 3.13, ensuring compatibility with the latest Python release.
	•	Minimal and safe change that aligns with the intended design of the code.

Thank you for your continued work on this project. Please let me know if you have any questions or need further modifications.