### PR TITLE
Bump libxml2 version to 2.14.5 for wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -110,7 +110,7 @@ jobs:
         include: ${{ fromJson(needs.generate-wheels-matrix.outputs.include) }}
 
     env:
-      PYXMLSEC_LIBXML2_VERSION: 2.14.4
+      PYXMLSEC_LIBXML2_VERSION: 2.14.5
       PYXMLSEC_LIBXSLT_VERSION: 1.1.43
 
     steps:


### PR DESCRIPTION
The goal is to keep it sync with lxml builds which in version 6.0.1 is using libxml2-2.14.5.