### PR TITLE
Lock libxml2 to v2.14.6 in manylinux workflow

### DIFF
--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Build linux_x86_64 wheel
         env:
           PYXMLSEC_STATIC_DEPS: true
+          PYXMLSEC_LIBXML2_VERSION: 2.14.6  # Lock it to libxml2 2.14.6 until the issue with 2.15.x is resolved; e.g. https://github.com/lsh123/xmlsec/issues/948
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           /opt/python/${{ matrix.python-abi }}/bin/python -m build

--- a/tests/softhsm_setup.py
+++ b/tests/softhsm_setup.py
@@ -140,7 +140,7 @@ log.level = DEBUG
                 )
 
         logging.debug('Initializing the token')
-        out, err = run_cmd(
+        _, _ = run_cmd(
             [
                 component_path['SOFTHSM'],
                 '--slot',


### PR DESCRIPTION
It seems that xmlsec library build fails with libxml2 v2.15.0. Let's lock it for now until the issue is resolved in the main repository.

https://github.com/lsh123/xmlsec/issues/948