### PR TITLE
Fix template.create argument parser signature

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -44,8 +44,8 @@ static PyObject* PyXmlSec_TemplateCreate(PyObject* self, PyObject *args, PyObjec
     xmlNodePtr res;
 
     PYXMLSEC_DEBUG("template create - start");
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O&O!O!|zzz:create", kwlist,
-        PyXmlSec_LxmlElementConverter, &node, PyXmlSec_TransformType, &c14n, PyXmlSec_TransformType, &sign, &id, &ns, &id))
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O&O!O!|zz:create", kwlist,
+        PyXmlSec_LxmlElementConverter, &node, PyXmlSec_TransformType, &c14n, PyXmlSec_TransformType, &sign, &id, &ns))
     {
         goto ON_FAIL;
     }


### PR DESCRIPTION
PyXmlSec_TemplateCreate still used the format string `O&O!O!|zzz:create` and passed a third optional string argument, even though `template.create()` only accepts two optional string parameters: `id` and `ns`.

Update the parser to use `|zz:create` and remove the stray extra `&id` argument so the C binding matches the Python API.

This fixes the runtime failure:

SystemError: more argument specifiers than keyword list entries (remaining format:'z:create')